### PR TITLE
Improve the hierarchical `LU` factorization

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "yas"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,42 @@
+# modified from https://github.com/SciML/DiffEqDocs.jl/tree/master/.github/workflows
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+
+      - uses: actions/checkout@v1
+      - name: Install JuliaFormatter and format
+        # This will use the latest version by default but you can set the version like so:
+        #
+        # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
+        run: |
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
+          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
+      - name: Format check
+        run: |
+          julia -e '
+          out = Cmd(`git diff --name-only`) |> read |> String
+          if out == ""
+              exit(0)
+          else
+              @error "Some files have not been formatted !!!"
+              write(stdout, out)
+              exit(1)
+          end'

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+DataFlowTasks = "d1549cb6-e9f4-42f8-98cc-ffc8d067ff5b"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -23,7 +23,7 @@ K = laplace_matrix(X, Y)
 irange = 1:N
 jrange = 1:N
 
-compressors = [PartialACA(rtol = rtol), ACA(rtol = rtol), TSVD(rtol = rtol)]
+compressors = [PartialACA(; rtol=rtol), ACA(; rtol=rtol), TSVD(; rtol=rtol)]
 
 for comp in compressors
     SUITE["Compressors"][string(comp)] = @benchmarkable $comp($K, $irange, $jrange)
@@ -53,26 +53,41 @@ comp = HMatrices.PartialACA(; rtol)
 step = 1.75 * π * radius / sqrt(N)
 k = 2 * π / (10 * step) # 10 pts per wavelength
 
-kernels = [
-    ("Laplace", laplace_matrix(X, X), true),
-    ("Helmholtz", helmholtz_matrix(X, X, k), true),
-    ("LaplaceVec", LaplaceMatrixVec(Xp,Xp), false),
-    ("HelmholtzVec", HelmholtzMatrixVec(Xp,Xp,k),false)
-]
+kernels = [("Laplace", laplace_matrix(X, X), true),
+           ("Helmholtz", helmholtz_matrix(X, X, k), true),
+           ("LaplaceVec", LaplaceMatrixVec(Xp, Xp), false),
+           ("HelmholtzVec", HelmholtzMatrixVec(Xp, Xp, k), false)]
 
 for (name, K, p) in kernels
     SUITE[name] = BenchmarkGroup([name, N])
     # bench assemble
-    SUITE[name]["assemble cpu"] = @benchmarkable assemble_hmat($K, $Xclt, $Xclt; adm = $adm, comp = $comp, threads = false, distributed = false, global_index = $p)
-    SUITE[name]["assemble threads"] = @benchmarkable assemble_hmat($K, $Xclt, $Xclt; adm = $adm, comp = $comp, threads = true, distributed = false, global_index = $p)
+    SUITE[name]["assemble cpu"] = @benchmarkable assemble_hmat($K,
+                                                               $Xclt,
+                                                               $Xclt;
+                                                               adm=$adm,
+                                                               comp=$comp,
+                                                               threads=false,
+                                                               distributed=false,
+                                                               global_index=$p)
+    SUITE[name]["assemble threads"] = @benchmarkable assemble_hmat($K,
+                                                                   $Xclt,
+                                                                   $Xclt;
+                                                                   adm=$adm,
+                                                                   comp=$comp,
+                                                                   threads=true,
+                                                                   distributed=false,
+                                                                   global_index=$p)
     # SUITE[name]["assemble procs"] = @benchmarkable assemble_hmat($K, $Xclt, $Xclt; adm = $adm, comp = $comp, threads = false, distributed = true, global_index = $p)
     # bench gemv only for regular case since the vectorized case should be the same
     if p
         x = rand(eltype(K), N)
         y = zero(x)
-        H = assemble_hmat(K, Xclt, Xclt; adm, comp, threads = true, distributed = false, global_index = p)
-        SUITE[name]["gemv cpu"] = @benchmarkable mul!($y, $H, $x, $1, $0; threads = false, global_index = $p)
-        SUITE[name]["gemv threads"] = @benchmarkable mul!($y, $H, $x, $1, $0; threads = true, global_index = $p)
-        SUITE[name]["lu"]     = @benchmarkable lu!($H;rank=5)
+        H = assemble_hmat(K, Xclt, Xclt; adm, comp, threads=true, distributed=false,
+                          global_index=p)
+        SUITE[name]["gemv cpu"] = @benchmarkable mul!($y, $H, $x, $1, $0; threads=false,
+                                                      global_index=$p)
+        SUITE[name]["gemv threads"] = @benchmarkable mul!($y, $H, $x, $1, $0; threads=true,
+                                                          global_index=$p)
+        SUITE[name]["lu"] = @benchmarkable lu!($H; rank=5)
     end
 end

--- a/benchmark/make.jl
+++ b/benchmark/make.jl
@@ -1,20 +1,18 @@
 using PkgBenchmark
 
-function postprocess(results,fname="benchs")
+function postprocess(results, fname="benchs")
     # writeresults(joinpath(path,fname),results)
     dir = @__DIR__
-    path = joinpath(dir,"../docs/src")
-    export_markdown(joinpath(path,fname*".md"),results)
+    path = joinpath(dir, "../docs/src")
+    return export_markdown(joinpath(path, fname * ".md"), results)
 end
 
-env = Dict("JULIA_NUM_THREADS" =>4,
-           "OPEN_BLAS_NUM_THREADS" => 1
-           )
+env = Dict("JULIA_NUM_THREADS" => 4, "OPEN_BLAS_NUM_THREADS" => 1)
 
-config = BenchmarkConfig(;juliacmd=`julia -O3`,env)
+config = BenchmarkConfig(; juliacmd=`julia -O3`, env)
 
-dir       = @__DIR__
-retune    = false
-results   = benchmarkpkg("HMatrices",config;retune)
+dir = @__DIR__
+retune = false
+results = benchmarkpkg("HMatrices", config; retune)
 
 postprocess(results)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,26 +4,19 @@ using Documenter
 DocMeta.setdocmeta!(HMatrices, :DocTestSetup, :(using HMatrices); recursive=true)
 
 makedocs(;
-    modules=[HMatrices],
-    authors="Luiz M. Faria <maltezfaria@gmail.com> and contributors",
-    repo="https://github.com/WaveProp/HMatrices.jl/blob/{commit}{path}#{line}",
-    sitename="HMatrices.jl",
-    format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://WaveProp.github.io/HMatrices.jl",
-        assets=String[],
-    ),
-    pages=[
-        "Getting started" => "index.md",
-        "Kernel matrices" => "kernelmatrix.md",
-        "Distributed HMatrix" => "dhmatrix.md",
-        "Notebooks" => "notebooks.md",
-        "Benchmarks" => ["benchs.md"],
-        "References" => "references.md"
-    ],
-)
+         modules=[HMatrices],
+         authors="Luiz M. Faria <maltezfaria@gmail.com> and contributors",
+         repo="https://github.com/WaveProp/HMatrices.jl/blob/{commit}{path}#{line}",
+         sitename="HMatrices.jl",
+         format=Documenter.HTML(;
+                                prettyurls=get(ENV, "CI", "false") == "true",
+                                canonical="https://WaveProp.github.io/HMatrices.jl",
+                                assets=String[]),
+         pages=["Getting started" => "index.md",
+                "Kernel matrices" => "kernelmatrix.md",
+                "Distributed HMatrix" => "dhmatrix.md",
+                "Notebooks" => "notebooks.md",
+                "Benchmarks" => ["benchs.md"],
+                "References" => "references.md"])
 
-deploydocs(;
-    repo="github.com/WaveProp/HMatrices.jl",
-    devbranch="main"
-)
+deploydocs(; repo="github.com/WaveProp/HMatrices.jl", devbranch="main")

--- a/src/HMatrices.jl
+++ b/src/HMatrices.jl
@@ -9,6 +9,7 @@ using TimerOutputs
 using Printf
 using RecipesBase
 using Distributed
+using DataFlowTasks
 
 import WavePropBase:
                      ClusterTree,
@@ -68,6 +69,16 @@ include("partitions.jl")
 include("multiplication.jl")
 include("triangular.jl")
 include("lu.jl")
+
+# interface of DataFlowTasks
+function DataFlowTasks.memory_overlap(H1::HMatrix, H2::HMatrix)
+    isempty(intersect(rowrange(H1),rowrange(H2))) && (return false)
+    isempty(intersect(colrange(H1),colrange(H2))) && (return false)
+    return true
+end
+
+DataFlowTasks.memory_overlap(H1::HMatrix, A::AbstractArray) = false
+DataFlowTasks.memory_overlap(A::AbstractArray,H1::HMatrix)  = false
 
 export
 # types (re-exported)

--- a/src/HMatrices.jl
+++ b/src/HMatrices.jl
@@ -71,14 +71,21 @@ include("triangular.jl")
 include("lu.jl")
 
 # interface of DataFlowTasks
-function DataFlowTasks.memory_overlap(H1::HMatrix, H2::HMatrix)
-    isempty(intersect(rowrange(H1),rowrange(H2))) && (return false)
-    isempty(intersect(colrange(H1),colrange(H2))) && (return false)
+import DataFlowTasks: memory_overlap
+function memory_overlap(H1::HMatrix, H2::HMatrix)
+    root(H1) == root(H2) || (return false)
+    isempty(intersect(rowrange(H1), rowrange(H2))) && (return false)
+    isempty(intersect(colrange(H1), colrange(H2))) && (return false)
     return true
 end
-
-DataFlowTasks.memory_overlap(H1::HMatrix, A::AbstractArray) = false
-DataFlowTasks.memory_overlap(A::AbstractArray,H1::HMatrix)  = false
+function memory_overlap(H1::HMatrix, pairs::Vector{<:NTuple{2,<:HMatrix}})
+    for (A, B) in pairs
+        memory_overlap(H1, A) && (return true)
+        memory_overlap(H1, B) && (return true)
+    end
+    return false
+end
+memory_overlap(pairs::Vector{<:NTuple{2,<:HMatrix}}, H::HMatrix) = memory_overlap(H, pairs)
 
 export
 # types (re-exported)

--- a/src/HMatrices.jl
+++ b/src/HMatrices.jl
@@ -9,7 +9,6 @@ using TimerOutputs
 using Printf
 using RecipesBase
 using Distributed
-using Base.Threads
 
 import WavePropBase:
     ClusterTree,
@@ -47,7 +46,7 @@ const ALLOW_GETINDEX = Ref(true)
 """
     use_threads()::Bool
 
-Default choice of whether threads will be used or not throught the package.
+Default choice of whether threads will be used or not throughout the package.
 """
 use_threads() = true
 
@@ -70,6 +69,17 @@ include("partitions.jl")
 include("multiplication.jl")
 include("triangular.jl")
 include("lu.jl")
+
+# interface of DataFlowTasks
+function DataFlowTasks.memory_overlap(H1::HMatrix, H2::HMatrix)
+    root(H1) === root(H2) || (return false)
+    isempty(intersect(rowrange(H1),rowrange(H2))) && (return false)
+    isempty(intersect(colrange(H1),colrange(H2))) && (return false)
+    return true
+end
+
+DataFlowTasks.memory_overlap(H1::HMatrix, A::AbstractArray) = false
+DataFlowTasks.memory_overlap(A::AbstractArray,H1::HMatrix)  = false
 
 export
     # types (re-exported)

--- a/src/HMatrices.jl
+++ b/src/HMatrices.jl
@@ -1,37 +1,36 @@
 module HMatrices
 
-const PROJECT_ROOT =  pkgdir(HMatrices)
+const PROJECT_ROOT = pkgdir(HMatrices)
 
 using StaticArrays
 using LinearAlgebra
-using Statistics:median
+using Statistics: median
 using TimerOutputs
 using Printf
 using RecipesBase
 using Distributed
 
 import WavePropBase:
-    ClusterTree,
-    CardinalitySplitter,
-    DyadicSplitter,
-    GeometricSplitter,
-    GeometricMinimalSplitter,
-    HyperRectangle,
-    AbstractTree,
-    filter_tree,
-    isleaf,
-    children,
-    parent,
-    index_range,
-    container,
-    center,
-    diameter,
-    distance,
-    root_elements,
-    loc2glob
+                     ClusterTree,
+                     CardinalitySplitter,
+                     DyadicSplitter,
+                     GeometricSplitter,
+                     GeometricMinimalSplitter,
+                     HyperRectangle,
+                     AbstractTree,
+                     filter_tree,
+                     isleaf,
+                     children,
+                     parent,
+                     index_range,
+                     container,
+                     center,
+                     diameter,
+                     distance,
+                     root_elements,
+                     loc2glob
 
-
-import AbstractTrees
+using AbstractTrees: AbstractTrees
 import LinearAlgebra: mul!, lu!, lu, LU, ldiv!, rdiv!, axpy!, rank, rmul!, lmul!
 import Base: Matrix, adjoint
 
@@ -70,40 +69,29 @@ include("multiplication.jl")
 include("triangular.jl")
 include("lu.jl")
 
-# interface of DataFlowTasks
-function DataFlowTasks.memory_overlap(H1::HMatrix, H2::HMatrix)
-    root(H1) === root(H2) || (return false)
-    isempty(intersect(rowrange(H1),rowrange(H2))) && (return false)
-    isempty(intersect(colrange(H1),colrange(H2))) && (return false)
-    return true
-end
-
-DataFlowTasks.memory_overlap(H1::HMatrix, A::AbstractArray) = false
-DataFlowTasks.memory_overlap(A::AbstractArray,H1::HMatrix)  = false
-
 export
-    # types (re-exported)
-    CardinalitySplitter,
-    ClusterTree,
-    DyadicSplitter,
-    GeometricSplitter,
-    GeometricMinimalSplitter,
-    HyperRectangle,
-    # abstract types
-    AbstractKernelMatrix,
-    # types
-    HMatrix,
-    KernelMatrix,
-    StrongAdmissibilityStd,
-    WeakAdmissibilityStd,
-    PartialACA,
-    ACA,
-    TSVD,
-    # functions
-    compression_ratio,
-    print_tree,
-    assemble_hmat,
-    # macros
-    @hprofile
+# types (re-exported)
+      CardinalitySplitter,
+      ClusterTree,
+      DyadicSplitter,
+      GeometricSplitter,
+      GeometricMinimalSplitter,
+      HyperRectangle,
+# abstract types
+      AbstractKernelMatrix,
+# types
+      HMatrix,
+      KernelMatrix,
+      StrongAdmissibilityStd,
+      WeakAdmissibilityStd,
+      PartialACA,
+      ACA,
+      TSVD,
+# functions
+      compression_ratio,
+      print_tree,
+      assemble_hmat,
+# macros
+      @hprofile
 
 end

--- a/src/addition.jl
+++ b/src/addition.jl
@@ -16,7 +16,7 @@ simply be assigned `X`. This means that after the call `axpy(a,X,Y)`, the object
 [`flush_to_leaves!`](@ref) or [`flush_to_children!`](@ref) follows.
 """
 function axpy!(a, X::Matrix, Y::RkMatrix)
-    axpy!(a, RkMatrix(X), Y)
+    return axpy!(a, RkMatrix(X), Y)
 end
 
 # 1.3
@@ -33,12 +33,12 @@ end
 function axpy!(a, X::Union{RkMatrix,RkMatrixBlockView}, Y::Matrix)
     # axpy!(a,Matrix(X),Y)
     r = rank(X)
-    m,n = size(Y)
+    m, n = size(Y)
     # @turbo warn_check_args=false for i in 1:m
     for i in 1:m
         for j in 1:n
             for k in 1:r
-                Y[i,j] += a*X.A[i, k] * conj(X.B[j, k])
+                Y[i, j] += a * X.A[i, k] * conj(X.B[j, k])
             end
         end
     end
@@ -82,7 +82,7 @@ function axpy!(a, X::HMatrix, Y::RkMatrix)
     # FIXME: inneficient implementation due to conversion from HMatrix to
     # Matrix. Does it really matter? I don't think this function should be
     # called.
-    axpy!(a, Matrix(X; global_index=false), Y)
+    return axpy!(a, Matrix(X; global_index=false), Y)
 end
 
 # 3.3
@@ -109,12 +109,12 @@ function axpy!(a, X::UniformScaling, Y::HMatrix)
         d = data(Y)
         @assert d isa Matrix
         n = min(size(d)...)
-        for i = 1:n
+        for i in 1:n
             d[i, i] += a * X.λ
         end
     else
         n = min(blocksize(Y)...)
-        for i = 1:n
+        for i in 1:n
             axpy!(a, X, children(Y)[i, i])
         end
     end

--- a/src/addition.jl
+++ b/src/addition.jl
@@ -15,100 +15,111 @@ simply be assigned `X`. This means that after the call `axpy(a,X,Y)`, the object
 `Y` is in a *dirty* state (see [`isclean`][@ref]) and usually a call to
 [`flush_to_leaves!`](@ref) or [`flush_to_children!`](@ref) follows.
 """
-function axpy!(a,X::Matrix,Y::RkMatrix)
-    axpy!(a,RkMatrix(X),Y)
+function axpy!(a, X::Matrix, Y::RkMatrix)
+    axpy!(a, RkMatrix(X), Y)
 end
 
 # 1.3
-function axpy!(a,X::Matrix,Y::HMatrix)
+function axpy!(a, X::Matrix, Y::HMatrix)
     if hasdata(Y)
-        axpy!(a,X,data(Y))
+        axpy!(a, X, data(Y))
     else
-        setdata!(Y,a*X)
+        setdata!(Y, a * X)
     end
     return Y
 end
 
 # 2.1
-function axpy!(a,X::RkMatrix,Y::Matrix)
-    axpy!(a,Matrix(X),Y)
+function axpy!(a, X::Union{RkMatrix,RkMatrixBlockView}, Y::Matrix)
+    # axpy!(a,Matrix(X),Y)
+    r = rank(X)
+    m,n = size(Y)
+    # @turbo warn_check_args=false for i in 1:m
+    for i in 1:m
+        for j in 1:n
+            for k in 1:r
+                Y[i,j] += a*X.A[i, k] * conj(X.B[j, k])
+            end
+        end
+    end
+    return Y
 end
 
 #2.2
-function axpy!(a,X::RkMatrix,Y::RkMatrix)
-    Y.A   = hcat(a*X.A,Y.A)
-    Y.B   = hcat(X.B,Y.B)
+function axpy!(a, X::RkMatrix, Y::RkMatrix)
+    Y.A = hcat(a * X.A, Y.A)
+    Y.B = hcat(X.B, Y.B)
     return Y
 end
 
 # 2.3
-function axpy!(a,X::RkMatrix,Y::HMatrix)
+function axpy!(a, X::RkMatrix, Y::HMatrix)
     if hasdata(Y)
-        axpy!(a,X,data(Y))
+        axpy!(a, X, data(Y))
     else
-        setdata!(Y,a*X)
+        setdata!(Y, a * X)
     end
     return Y
 end
 
 #3.1
-function axpy!(a,X::HMatrix,Y::Matrix)
+function axpy!(a, X::HMatrix, Y::Matrix)
     @debug "calling axpy! with `X` and HMatrix and `Y` a Matrix"
     shift = pivot(X) .- 1
     for block in AbstractTrees.PreOrderDFS(X)
         irange = rowrange(block) .- shift[1]
         jrange = colrange(block) .- shift[2]
         if hasdata(block)
-            axpy!(a,data(block),view(Y,irange,jrange))
+            axpy!(a, data(block), view(Y, irange, jrange))
         end
     end
     return Y
 end
 
 # 3.2
-function axpy!(a,X::HMatrix,Y::RkMatrix)
+function axpy!(a, X::HMatrix, Y::RkMatrix)
     @debug "calling axpby! with `X` and HMatrix and `Y` an RkMatrix"
     # FIXME: inneficient implementation due to conversion from HMatrix to
     # Matrix. Does it really matter? I don't think this function should be
     # called.
-    axpy!(a,Matrix(X;global_index=false),Y)
+    axpy!(a, Matrix(X; global_index=false), Y)
 end
 
 # 3.3
-function axpy!(a,X::HMatrix,Y::HMatrix)
+function axpy!(a, X::HMatrix, Y::HMatrix)
     # TODO: assumes X and Y have the same structure. How to reinforce this?
     if hasdata(X)
         if hasdata(Y)
-            axpy!(a,data(X),Y)
+            axpy!(a, data(X), Y)
         else
-            setdata!(Y,a*data(X))
+            setdata!(Y, a * data(X))
         end
     end
     @assert size(children(X)) == size(children(Y)) "adding hierarchical matrices requires identical block structure"
-    for (bx,by) in zip(children(X),children(Y))
-        axpy!(a,bx,by)
+    for (bx, by) in zip(children(X), children(Y))
+        axpy!(a, bx, by)
     end
     return Y
 end
 
 # add a unifor scaling to an HMatrix return an HMatrix
-function axpy!(a,X::UniformScaling,Y::HMatrix)
+function axpy!(a, X::UniformScaling, Y::HMatrix)
     @assert isclean(Y)
     if hasdata(Y)
         d = data(Y)
         @assert d isa Matrix
         n = min(size(d)...)
-        for i=1:n
-            d[i,i] += a*X.λ
+        for i = 1:n
+            d[i, i] += a * X.λ
         end
     else
         n = min(blocksize(Y)...)
-        for i=1:n
-            axpy!(a,X,children(Y)[i,i])
+        for i = 1:n
+            axpy!(a, X, children(Y)[i, i])
         end
     end
     return Y
 end
 
-Base.:(+)(X::UniformScaling,Y::HMatrix) = axpy!(true,X,deepcopy(Y))
-Base.:(+)(X::HMatrix,Y::UniformScaling) = Y+X
+Base.:(+)(X::UniformScaling, Y::HMatrix) = axpy!(true, X, deepcopy(Y))
+Base.:(+)(X::HMatrix, Y::UniformScaling) = Y + X

--- a/src/compressor.jl
+++ b/src/compressor.jl
@@ -33,24 +33,24 @@ true
 
 ```
 """
-@Base.kwdef struct ACA
+Base.@kwdef struct ACA
     atol::Float64 = 0
-    rank::Int     = typemax(Int)
-    rtol::Float64 = atol>0 || rank<typemax(Int) ? 0 : sqrt(eps(Float64))
+    rank::Int = typemax(Int)
+    rtol::Float64 = atol > 0 || rank < typemax(Int) ? 0 : sqrt(eps(Float64))
 end
 
-function (aca::ACA)(K,rowtree::ClusterTree,coltree::ClusterTree)
+function (aca::ACA)(K, rowtree::ClusterTree, coltree::ClusterTree)
     irange = index_range(rowtree)
     jrange = index_range(coltree)
-    aca(K,irange,jrange)
+    aca(K, irange, jrange)
 end
 
-function (aca::ACA)(K,irange,jrange)
-    M  = K[irange,jrange] # computes the entire matrix.
-    _aca_full!(M,aca.atol,aca.rank,aca.rtol)
+function (aca::ACA)(K, irange, jrange)
+    M = K[irange, jrange] # computes the entire matrix.
+    _aca_full!(M, aca.atol, aca.rank, aca.rtol)
 end
 
-(comp::ACA)(K::Matrix) = comp(K,1:size(K,1),1:size(K,2))
+(comp::ACA)(K::Matrix) = comp(K, 1:size(K, 1), 1:size(K, 2))
 
 """
     _aca_full!(M,atol,rmax,rtol)
@@ -60,35 +60,35 @@ full pivoting. The matrix `M` is modified in place. The returned `RkMatrix` has
 rank at most `rmax`, and is expected to satisfy `|M - R| < max(atol,rtol*|M|)`.
 """
 function _aca_full!(M, atol, rmax, rtol)
-    Madj  = adjoint(M)
-    T   = eltype(M)
-    m,n = size(M)
-    A   = Vector{Vector{T}}()
-    B   = Vector{Vector{T}}()
+    Madj = adjoint(M)
+    T = eltype(M)
+    m, n = size(M)
+    A = Vector{Vector{T}}()
+    B = Vector{Vector{T}}()
     er = Inf
-    exact_norm = norm(M,2) # exact norm
+    exact_norm = norm(M, 2) # exact norm
     r = 0 # current rank
-    while er > max(atol,rtol*exact_norm) && r < rmax
+    while er > max(atol, rtol * exact_norm) && r < rmax
         I = _aca_full_pivot(M)
-        i,j = Tuple(I)
-        δ   = M[I]
+        i, j = Tuple(I)
+        δ = M[I]
         if svdvals(δ)[end] == 0
-            return RkMatrix(A,B)
+            return RkMatrix(A, B)
         else
             iδ = inv(δ)
-            col  = M[:,j]
-            adjcol  = Madj[:,i]
+            col = M[:, j]
+            adjcol = Madj[:, i]
             for k in eachindex(adjcol)
-                adjcol[k] = adjcol[k]*adjoint(iδ)
+                adjcol[k] = adjcol[k] * adjoint(iδ)
             end
             r += 1
-            push!(A,col)
-            push!(B,adjcol)
-            axpy!(-1,col*adjoint(adjcol),M) # M <-- M - col*row'
-            er = norm(M,2) # exact error
+            push!(A, col)
+            push!(B, adjcol)
+            axpy!(-1, col * adjoint(adjcol), M) # M <-- M - col*row'
+            er = norm(M, 2) # exact error
         end
     end
-    return RkMatrix(A,B)
+    return RkMatrix(A, B)
 end
 
 """
@@ -118,25 +118,25 @@ evaluated at every `i,j`. This is usually much faster than [`ACA`](@ref), but
 due to the pivoting strategy the algorithm may fail in special cases, even when
 the underlying linear operator is of low rank.
 """
-@Base.kwdef struct PartialACA
+Base.@kwdef struct PartialACA
     atol::Float64 = 0
-    rank::Int     = typemax(Int)
-    rtol::Float64 = atol>0 || rank<typemax(Int) ? 0 : sqrt(eps(Float64))
+    rank::Int = typemax(Int)
+    rtol::Float64 = atol > 0 || rank < typemax(Int) ? 0 : sqrt(eps(Float64))
 end
 
-function (paca::PartialACA)(K,rowtree::ClusterTree,coltree::ClusterTree)
+function (paca::PartialACA)(K, rowtree::ClusterTree, coltree::ClusterTree)
     # find initial column pivot for partial ACA
     istart = _aca_partial_initial_pivot(rowtree)
     irange = index_range(rowtree)
     jrange = index_range(coltree)
-    _aca_partial(K,irange,jrange,paca.atol,paca.rank,paca.rtol,istart-irange.start+1)
+    _aca_partial(K, irange, jrange, paca.atol, paca.rank, paca.rtol, istart - irange.start + 1)
 end
 
-function (paca::PartialACA)(K,irange::UnitRange,jrange::UnitRange)
-    _aca_partial(K,irange,jrange,paca.atol,paca.rank,paca.rtol)
+function (paca::PartialACA)(K, irange::Union{<:UnitRange,Colon}, jrange::Union{<:UnitRange,Colon})
+    _aca_partial(K, irange, jrange, paca.atol, paca.rank, paca.rtol)
 end
 
-(paca::PartialACA)(K::Matrix) = paca(K,1:size(K,1),1:size(K,2))
+(paca::PartialACA)(K) = paca(K, :, :)
 
 
 """
@@ -144,77 +144,77 @@ end
 
 Internal function implementing the adaptive cross-approximation algorithm with
 partial pivoting. The returned `R::RkMatrix` provides an approximation to
-`K[irange,jrange]` which has either rank `is expected to satisfy `|M - R| <
-max(atol,rtol*|M|)`, but this inequality may fail to hold due to the various
-errors involved in estimating the error and |M|.
+`K[irange,jrange]` which has rank `r<rmax``, and is expected to satisfy `|M - R|
+< max(atol,rtol*|M|)` (but this inequality may fail to hold due to the various
+errors involved in estimating the error and |M|).
 """
-function _aca_partial(K,irange,jrange,atol,rmax,rtol,istart=1)
+function _aca_partial(K, irange, jrange, atol, rmax, rtol, istart=1)
     Kadj = adjoint(K)
     # if irange and jrange are Colon, extract the size from `K` directly. This
     # allows for some code reuse with specializations on getindex(i,::Colon) and
     # getindex(::Colon,j) for when `K` is a `RkMatrix`
     if irange isa Colon && jrange isa Colon
-        m,n = size(K)
-        ishift,jshift = 0,0
+        m, n = size(K)
+        ishift, jshift = 0, 0
     else
-        m,n = length(irange), length(jrange)
-        ishift,jshift = irange.start-1, jrange.start-1
+        m, n = length(irange), length(jrange)
+        ishift, jshift = irange.start - 1, jrange.start - 1
         # maps global indices to local indices
     end
-    rmax = min(m,n,rmax)
-    T   = Base.eltype(K)
-    A   = Vector{Vector{T}}()
-    B   = Vector{Vector{T}}()
-    I   = BitVector(true for i = 1:m)
-    J   = BitVector(true for i = 1:n)
-    i   = istart # initial pivot
-    er  = Inf
+    rmax = min(m, n, rmax)
+    T = Base.eltype(K)
+    A = Vector{Vector{T}}()
+    B = Vector{Vector{T}}()
+    I = BitVector(true for i = 1:m)
+    J = BitVector(true for i = 1:n)
+    i = istart # initial pivot
+    er = Inf
     est_norm = 0 # approximate norm of K[irange,jrange]
-    r   = 0 # current rank
-    while er > max(atol,rtol*est_norm) && r < rmax
+    r = 0 # current rank
+    while er > max(atol, rtol * est_norm) && r < rmax
         # remove index i from allowed row
         I[i] = false
         # compute next row by row <-- K[i+ishift,jrange] - R[i,:]
-        adjcol = Kadj[jrange,i+ishift]
+        adjcol = Kadj[jrange, i+ishift]
         for k = 1:r
-            axpy!(-adjoint(A[k][i]),B[k],adjcol)
+            axpy!(-adjoint(A[k][i]), B[k], adjcol)
             # for j in eachindex(row)
             #     row[j] = row[j] - B[k][j]*adjoint(A[k][i])
             # end
         end
-        j    = _aca_partial_pivot(adjcol,J)
-        δ    = adjcol[j]
+        j = _aca_partial_pivot(adjcol, J)
+        δ = adjcol[j]
         if svdvals(δ)[end] == 0
             @debug "zero pivot found during partial aca"
-            i = findfirst(x->x==true,I)
+            i = findfirst(x -> x == true, I)
         else # δ != 0
             iδ = inv(δ)
             # rdiv!(b,δ) # b <-- b/δ
             for k in eachindex(adjcol)
-                adjcol[k] = adjcol[k]*iδ
+                adjcol[k] = adjcol[k] * iδ
             end
             J[j] = false
             # compute next col by col <-- K[irange,j+jshift] - R[:,j]
-            col    = K[irange,j+jshift]
+            col = K[irange, j+jshift]
             for k = 1:r
-                axpy!(-adjoint(B[k][j]),A[k],col)
+                axpy!(-adjoint(B[k][j]), A[k], col)
                 # for i in eachindex(col)
                 #     col[i] = col[i] - A[k][i]*adjoint(B[k][j])
                 # end
             end
             # push new cross and increase rank
             r += 1
-            push!(A,col)
-            push!(B,adjcol)
+            push!(A, col)
+            push!(B, adjcol)
             # estimate the error by || R_{k} - R_{k-1} || = ||a|| ||b||
-            er       = norm(col)*norm(adjcol)
+            er = norm(col) * norm(adjcol)
             # estimate the norm by || K || ≈ || R_k ||
-            est_norm = _update_frob_norm(est_norm,A,B)
-            i        = _aca_partial_pivot(col,I)
+            est_norm = _update_frob_norm(est_norm, A, B)
+            i = _aca_partial_pivot(col, I)
             # @show r, er
         end
     end
-    return RkMatrix(A,B)
+    return RkMatrix(A, B)
 end
 
 """
@@ -223,15 +223,13 @@ end
 Given the Frobenius norm of `Rₖ = A[1:end-1]*adjoint(B[1:end-1])` in `acc`,
 compute the Frobenius norm of `Rₖ₊₁ = A*adjoint(B)` efficiently.
 """
-@inline function _update_frob_norm(cur,A,B)
-    @timeit_debug "Update Frobenius norm" begin
-        k = length(A)
-        a = A[end]
-        b = B[end]
-        out = norm(a)^2 * norm(b)^2
-        for l=1:k-1
-            out += 2*real(dot(A[l],a)*(dot(b,B[l])))
-        end
+@inline function _update_frob_norm(cur, A, B)
+    k = length(A)
+    a = A[end]
+    b = B[end]
+    out = norm(a)^2 * norm(b)^2
+    for l = 1:k-1
+        out += 2 * real(dot(A[l], a) * (dot(b, B[l])))
     end
     return sqrt(cur^2 + out)
 end
@@ -250,13 +248,13 @@ kernels; see
 (https://www.sciencedirect.com/science/article/pii/S0021999117306721)[https://www.sciencedirect.com/science/article/pii/S0021999117306721]
 for more details.
 """
-function _aca_partial_pivot(v,J)
+function _aca_partial_pivot(v, J)
     idx = -1
     val = -Inf
     for n in 1:length(J)
         J[n] || continue
-        x   = v[n]
-        σ   = svdvals(x)[end]
+        x = v[n]
+        σ = svdvals(x)[end]
         σ < val && continue
         idx = n
         val = σ
@@ -276,11 +274,11 @@ When `x` is a scalar, this is simply the element with largest absolute value.
 """
 function _aca_full_pivot(M)
     idxs = CartesianIndices(M)
-    idx  = first(idxs)
+    idx = first(idxs)
     val = -Inf
     for I in idxs
-        x   = M[I]
-        σ   = svdvals(x)[end]
+        x = M[I]
+        σ = svdvals(x)[end]
         σ < val && continue
         idx = I
         val = σ
@@ -292,15 +290,15 @@ function _aca_partial_initial_pivot(rowtree)
     # the method below is suggested in Bebendorf, but it does not seem to
     # improve the  error. The idea is that the initial pivot is the closesest
     # point to the center of the cluster
-    xc        = center(container(rowtree))
-    d         = Inf
-    els       = root_elements(rowtree)
-    loc_idxs  = index_range(rowtree)
-    istart    = first(loc_idxs)
+    xc = center(container(rowtree))
+    d = Inf
+    els = root_elements(rowtree)
+    loc_idxs = index_range(rowtree)
+    istart = first(loc_idxs)
     for i in loc_idxs
-        x     = els[i]
-        if norm(x-xc) < d
-            d      = norm(x-xc)
+        x = els[i]
+        if norm(x - xc) < d
+            d = norm(x - xc)
             istart = i
         end
     end
@@ -314,24 +312,24 @@ Compression algorithm based on *a posteriori* truncation of an `SVD`. This is
 the optimal approximation in Frobenius norm; however, it also tends to be very
 expensive and thus should be used mostly for "small" matrices.
 """
-@Base.kwdef struct TSVD
+Base.@kwdef struct TSVD
     atol::Float64 = 0
-    rank::Int     = typemax(Int)
-    rtol::Float64 = atol>0 || rank<typemax(Int) ? 0 : sqrt(eps(Float64))
+    rank::Int = typemax(Int)
+    rtol::Float64 = atol > 0 || rank < typemax(Int) ? 0 : sqrt(eps(Float64))
 end
 
-function (tsvd::TSVD)(K,rowtree::ClusterTree,coltree::ClusterTree)
+function (tsvd::TSVD)(K, rowtree::ClusterTree, coltree::ClusterTree)
     irange = index_range(rowtree)
     jrange = index_range(coltree)
-    tsvd(K,irange,jrange)
+    tsvd(K, irange, jrange)
 end
 
-function (tsvd::TSVD)(K,irange::UnitRange,jrange::UnitRange)
-    M = K[irange,jrange]
-    compress!(M,tsvd)
+function (tsvd::TSVD)(K, irange::UnitRange, jrange::UnitRange)
+    M = K[irange, jrange]
+    compress!(M, tsvd)
 end
 
-(comp::TSVD)(K::Matrix) = comp(K,1:size(K,1),1:size(K,2))
+(comp::TSVD)(K::Matrix) = comp(K, 1:size(K, 1), 1:size(K, 2))
 
 """
     compress!(M::RkMatrix,tsvd::TSVD)
@@ -340,26 +338,26 @@ Recompress the matrix `R` using a truncated svd of `R`. The implementation uses
 the `qr-svd` strategy to efficiently compute `svd(R)` when `rank(R) ≪
 min(size(R))`.
 """
-function compress!(R::RkMatrix,tsvd::TSVD)
-    m,n   = size(R)
+function compress!(R::RkMatrix, tsvd::TSVD)
+    m, n = size(R)
     QA, RA = qr!(R.A)
     QB, RB = qr!(R.B)
-    F      = svd!(RA*adjoint(RB)) # svd of an r×r problem
-    U      = QA*F.U
-    Vt     = F.Vt*adjoint(QB)
-    V      = adjoint(Vt)
+    F = svd!(RA * adjoint(RB)) # svd of an r×r problem
+    U = QA * F.U
+    Vt = F.Vt * adjoint(QB)
+    V = adjoint(Vt)
     sp_norm = F.S[1] # spectral norm
-    r     = findlast(x -> x>max(tsvd.atol,tsvd.rtol*sp_norm), F.S)
-    isnothing(r) && (r = min(rank(R),m,n))
-    r = min(r,tsvd.rank)
-    if m<n
-        A = @views U[:,1:r]*Diagonal(F.S[1:r])
-        B = V[:,1:r]
+    r = findlast(x -> x > max(tsvd.atol, tsvd.rtol * sp_norm), F.S)
+    isnothing(r) && (r = min(rank(R), m, n))
+    r = min(r, tsvd.rank)
+    if m < n
+        A = @views U[:, 1:r] * Diagonal(F.S[1:r])
+        B = V[:, 1:r]
     else
-        A = U[:,1:r]
-        B = @views (V[:,1:r])*Diagonal(F.S[1:r])
+        A = U[:, 1:r]
+        B = @views (V[:, 1:r]) * Diagonal(F.S[1:r])
     end
-    R.A,R.B = A,B
+    R.A, R.B = A, B
     return R
 end
 
@@ -369,19 +367,19 @@ end
 Recompress the matrix `M` using a truncated svd and output an `RkMatrix`. The
 data in `M` is invalidated in the process.
 """
-function compress!(M::Matrix,tsvd::TSVD)
-    m,n = size(M)
-    F      = svd!(M)
+function compress!(M::Matrix, tsvd::TSVD)
+    m, n = size(M)
+    F = svd!(M)
     sp_norm = F.S[1] # spectral norm
-    r     = findlast(x -> x>max(tsvd.atol,tsvd.rtol*sp_norm), F.S)
-    isnothing(r) && (r = min(m,n))
-    r = min(r,tsvd.rank)
-    if m<n
-        A = @views F.U[:,1:r]*Diagonal(F.S[1:r])
-        B = F.V[:,1:r]
+    r = findlast(x -> x > max(tsvd.atol, tsvd.rtol * sp_norm), F.S)
+    isnothing(r) && (r = min(m, n))
+    r = min(r, tsvd.rank)
+    if m < n
+        A = @views F.U[:, 1:r] * Diagonal(F.S[1:r])
+        B = F.V[:, 1:r]
     else
-        A = F.U[:,1:r]
-        B = @views (F.V[:,1:r])*Diagonal(F.S[1:r])
+        A = F.U[:, 1:r]
+        B = @views (F.V[:, 1:r]) * Diagonal(F.S[1:r])
     end
-    return RkMatrix(A,B)
+    return RkMatrix(A, B)
 end

--- a/src/compressor.jl
+++ b/src/compressor.jl
@@ -42,12 +42,12 @@ end
 function (aca::ACA)(K, rowtree::ClusterTree, coltree::ClusterTree)
     irange = index_range(rowtree)
     jrange = index_range(coltree)
-    aca(K, irange, jrange)
+    return aca(K, irange, jrange)
 end
 
 function (aca::ACA)(K, irange, jrange)
     M = K[irange, jrange] # computes the entire matrix.
-    _aca_full!(M, aca.atol, aca.rank, aca.rtol)
+    return _aca_full!(M, aca.atol, aca.rank, aca.rtol)
 end
 
 (comp::ACA)(K::Matrix) = comp(K, 1:size(K, 1), 1:size(K, 2))
@@ -129,15 +129,16 @@ function (paca::PartialACA)(K, rowtree::ClusterTree, coltree::ClusterTree)
     istart = _aca_partial_initial_pivot(rowtree)
     irange = index_range(rowtree)
     jrange = index_range(coltree)
-    _aca_partial(K, irange, jrange, paca.atol, paca.rank, paca.rtol, istart - irange.start + 1)
+    return _aca_partial(K, irange, jrange, paca.atol, paca.rank, paca.rtol,
+                        istart - irange.start + 1)
 end
 
-function (paca::PartialACA)(K, irange::Union{<:UnitRange,Colon}, jrange::Union{<:UnitRange,Colon})
-    _aca_partial(K, irange, jrange, paca.atol, paca.rank, paca.rtol)
+function (paca::PartialACA)(K, irange::Union{<:UnitRange,Colon},
+                            jrange::Union{<:UnitRange,Colon})
+    return _aca_partial(K, irange, jrange, paca.atol, paca.rank, paca.rtol)
 end
 
 (paca::PartialACA)(K) = paca(K, :, :)
-
 
 """
     _aca_partial(K,irange,jrange,atol,rmax,rtol,istart=1)
@@ -165,8 +166,8 @@ function _aca_partial(K, irange, jrange, atol, rmax, rtol, istart=1)
     T = Base.eltype(K)
     A = Vector{Vector{T}}()
     B = Vector{Vector{T}}()
-    I = BitVector(true for i = 1:m)
-    J = BitVector(true for i = 1:n)
+    I = BitVector(true for i in 1:m)
+    J = BitVector(true for i in 1:n)
     i = istart # initial pivot
     er = Inf
     est_norm = 0 # approximate norm of K[irange,jrange]
@@ -175,8 +176,8 @@ function _aca_partial(K, irange, jrange, atol, rmax, rtol, istart=1)
         # remove index i from allowed row
         I[i] = false
         # compute next row by row <-- K[i+ishift,jrange] - R[i,:]
-        adjcol = Kadj[jrange, i+ishift]
-        for k = 1:r
+        adjcol = Kadj[jrange, i + ishift]
+        for k in 1:r
             axpy!(-adjoint(A[k][i]), B[k], adjcol)
             # for j in eachindex(row)
             #     row[j] = row[j] - B[k][j]*adjoint(A[k][i])
@@ -195,8 +196,8 @@ function _aca_partial(K, irange, jrange, atol, rmax, rtol, istart=1)
             end
             J[j] = false
             # compute next col by col <-- K[irange,j+jshift] - R[:,j]
-            col = K[irange, j+jshift]
-            for k = 1:r
+            col = K[irange, j + jshift]
+            for k in 1:r
                 axpy!(-adjoint(B[k][j]), A[k], col)
                 # for i in eachindex(col)
                 #     col[i] = col[i] - A[k][i]*adjoint(B[k][j])
@@ -228,7 +229,7 @@ compute the Frobenius norm of `Rₖ₊₁ = A*adjoint(B)` efficiently.
     a = A[end]
     b = B[end]
     out = norm(a)^2 * norm(b)^2
-    for l = 1:k-1
+    for l in 1:(k - 1)
         out += 2 * real(dot(A[l], a) * (dot(b, B[l])))
     end
     return sqrt(cur^2 + out)
@@ -321,12 +322,12 @@ end
 function (tsvd::TSVD)(K, rowtree::ClusterTree, coltree::ClusterTree)
     irange = index_range(rowtree)
     jrange = index_range(coltree)
-    tsvd(K, irange, jrange)
+    return tsvd(K, irange, jrange)
 end
 
 function (tsvd::TSVD)(K, irange::UnitRange, jrange::UnitRange)
     M = K[irange, jrange]
-    compress!(M, tsvd)
+    return compress!(M, tsvd)
 end
 
 (comp::TSVD)(K::Matrix) = comp(K, 1:size(K, 1), 1:size(K, 2))

--- a/src/dhmatrix.jl
+++ b/src/dhmatrix.jl
@@ -3,8 +3,8 @@ using Distributed
 function typeof_future(r::Future)
     if isready(r)
         pid = r.where
-        f   = @spawnat pid typeof(fetch(r))
-        T   = fetch(f)
+        f = @spawnat pid typeof(fetch(r))
+        T = fetch(f)
         return T
     else
         error("future is not ready")
@@ -23,9 +23,9 @@ end
 
 Base.fetch(r::RemoteHMatrix) = fetch(r.future)
 
-function Base.getindex(r::RemoteHMatrix,i::Int,j::Int)
+function Base.getindex(r::RemoteHMatrix, i::Int, j::Int)
     pid = r.future.where
-    @fetchfrom pid getindex(fetch(r),i,j)
+    @fetchfrom pid getindex(fetch(r), i, j)
 end
 
 """
@@ -46,10 +46,10 @@ mutable struct DHMatrix{R,T} <: AbstractHMatrix{T}
     children::Matrix{DHMatrix{R,T}}
     parent::DHMatrix{R,T}
     # inner constructor which handles `nothing` fields.
-    function DHMatrix{R,T}(rowtree,coltree,data,children,parent) where {R,T}
-        dhmat = new{R,T}(rowtree,coltree,data)
-        dhmat.children = isnothing(children) ? Matrix{DHMatrix{R,T}}(undef,0,0) : children
-        dhmat.parent   = isnothing(parent) ? dhmat : parent
+    function DHMatrix{R,T}(rowtree, coltree, data, children, parent) where {R,T}
+        dhmat = new{R,T}(rowtree, coltree, data)
+        dhmat.children = isnothing(children) ? Matrix{DHMatrix{R,T}}(undef, 0, 0) : children
+        dhmat.parent = isnothing(parent) ? dhmat : parent
         return dhmat
     end
 end
@@ -65,22 +65,24 @@ for distributed computing. Currently, the only available options is
 `distribute_columns`, which will partition the columns of the underlying matrix
 into `floor(log2(nw))` parts, where `nw` is the number of workers available.
 """
-function DHMatrix{T}(rowtree::R, coltree::R; partition_strategy=:distribute_columns) where {R,T}
+function DHMatrix{T}(rowtree::R, coltree::R;
+                     partition_strategy=:distribute_columns) where {R,T}
     #build root
-    root  = DHMatrix{R,T}(rowtree,coltree,nothing,nothing,nothing)
+    root = DHMatrix{R,T}(rowtree, coltree, nothing, nothing, nothing)
     # depending on the partition strategy, dispatch to appropriate (recursive)
     # method
     if partition_strategy == :distribute_columns
-        nw        = nworkers()
-        dmax      = floor(Int64,log2(nw))
-        _build_block_structure_distribute_cols!(root,dmax)
+        nw = nworkers()
+        dmax = floor(Int64, log2(nw))
+        _build_block_structure_distribute_cols!(root, dmax)
     else
         error("unrecognized partition strategy")
     end
     return root
 end
 
-function _build_block_structure_distribute_cols!(current_node::DHMatrix{R,T},dmax) where {R,T}
+function _build_block_structure_distribute_cols!(current_node::DHMatrix{R,T},
+                                                 dmax) where {R,T}
     if Trees.depth(current_node) == dmax
         return current_node
     else
@@ -90,10 +92,12 @@ function _build_block_structure_distribute_cols!(current_node::DHMatrix{R,T},dma
         # do not recurse on row, only on columns
         row_children = [X]
         col_children = Y.children
-        children     = [DHMatrix{R,T}(r,c,nothing,nothing,current_node) for r in row_children, c in col_children]
+        children = [DHMatrix{R,T}(r, c, nothing, nothing, current_node)
+                    for r in row_children,
+                        c in col_children]
         current_node.children = children
         for child in children
-            _build_block_structure_distribute_cols!(child,dmax)
+            _build_block_structure_distribute_cols!(child, dmax)
         end
         return current_node
     end
@@ -101,17 +105,18 @@ end
 
 Base.size(H::DHMatrix) = length(rowrange(H)), length(colrange(H))
 
-function Base.show(io::IO,::MIME"text/plain",hmat::DHMatrix)
+function Base.show(io::IO, ::MIME"text/plain", hmat::DHMatrix)
     # isclean(hmat) || return print(io,"Dirty DHMatrix")
-    println(io,"Distributed HMatrix of $(eltype(hmat)) with range $(rowrange(hmat)) × $(colrange(hmat))")
+    println(io,
+            "Distributed HMatrix of $(eltype(hmat)) with range $(rowrange(hmat)) × $(colrange(hmat))")
     nodes = collect(AbstractTrees.PreOrderDFS(hmat))
-    println(io,"\t number of nodes in tree: $(length(nodes))")
+    println(io, "\t number of nodes in tree: $(length(nodes))")
     leaves = collect(AbstractTrees.Leaves(hmat))
-    @printf(io,"\t number of leaves: %i\n",length(leaves))
-    for (i,leaf) in enumerate(leaves)
-        r   = leaf.data.future
+    @printf(io, "\t number of leaves: %i\n", length(leaves))
+    for (i, leaf) in enumerate(leaves)
+        r = leaf.data.future
         pid = r.where
-        irange,jrange = @fetchfrom pid rowrange(fetch(r)), colrange(fetch(r))
+        irange, jrange = @fetchfrom pid rowrange(fetch(r)), colrange(fetch(r))
         println("\t\t leaf $i on process $pid spanning $irange × $jrange")
     end
 end
@@ -122,58 +127,76 @@ end
 Internal methods called **after** the `DHMatrix` structure has been initialized
 in order to construct the `HMatrix` on each of the leaves of the `DHMatrix`.
 """
-function _assemble_hmat_distributed(K,rtree,ctree;adm=StrongAdmissibilityStd(),comp=PartialACA(),
-                                    global_index=use_global_index(),threads=use_threads())
+function _assemble_hmat_distributed(K,
+                                    rtree,
+                                    ctree;
+                                    adm=StrongAdmissibilityStd(),
+                                    comp=PartialACA(),
+                                    global_index=use_global_index(),
+                                    threads=use_threads())
     #
     R = typeof(rtree)
     T = eltype(K)
-    wids   = workers()
-    root   = DHMatrix{T}(rtree,ctree;partition_strategy=:distribute_columns)
-    leaves = AbstractTrees.Leaves(root) |> collect
+    wids = workers()
+    root = DHMatrix{T}(rtree, ctree; partition_strategy=:distribute_columns)
+    leaves = collect(AbstractTrees.Leaves(root))
     @info "Assembling distributed HMatrix on $(length(leaves)) processes"
     @sync for (k, leaf) in enumerate(leaves)
         pid = wids[k] # id of k-th worker
-        r   = @spawnat pid assemble_hmat(K, rowtree(leaf), coltree(leaf); adm, comp,global_index,threads,distributed=false)
+        r = @spawnat pid assemble_hmat(K,
+                                       rowtree(leaf),
+                                       coltree(leaf);
+                                       adm,
+                                       comp,
+                                       global_index,
+                                       threads,
+                                       distributed=false)
         leaf.data = RemoteHMatrix{R,T}(r)
     end
     return root
 end
 
-function mul!(y::AbstractVector,A::DHMatrix,x::AbstractVector,a::Number,b::Number;
-                            global_index=use_global_index(),threads=use_threads())
+function mul!(y::AbstractVector,
+              A::DHMatrix,
+              x::AbstractVector,
+              a::Number,
+              b::Number;
+              global_index=use_global_index(),
+              threads=use_threads())
     # since the HMatrix represents A = Pr*H*Pc, where Pr and Pc are row and column
     # permutations, we need first to rewrite C <-- b*C + a*(Pc*H*Pb)*B as
     # C <-- Pr*(b*inv(Pr)*C + a*H*(Pc*B)). Following this rewrite, the
     # multiplication is performed by first defining B <-- Pc*B, and C <--
     # inv(Pr)*C, doing the multiplication with the permuted entries, and then
     # permuting the result  C <-- Pr*C at the end.
-    ctree     = A.coltree
-    rtree     = A.rowtree
+    ctree = A.coltree
+    rtree = A.rowtree
     # permute input
     if global_index
-        x         = x[ctree.loc2glob]
-        y         = permute!(y,rtree.loc2glob)
-        rmul!(x,a) # multiply in place since this is a new copy, so does not mutate exterior x
+        x = x[ctree.loc2glob]
+        y = permute!(y, rtree.loc2glob)
+        rmul!(x, a) # multiply in place since this is a new copy, so does not mutate exterior x
     else
-        x = a*x # new copy of x
+        x = a * x # new copy of x
     end
-    rmul!(y,b)
-    leaves = filter_tree(x->Trees.isleaf(x),A)
-    nb  = length(leaves)
-    acc = Vector{Future}(undef,nb)
+    rmul!(y, b)
+    leaves = filter_tree(x -> Trees.isleaf(x), A)
+    nb = length(leaves)
+    acc = Vector{Future}(undef, nb)
     @sync for i in 1:nb
-        r        = leaves[i].data.future
-        pid      = r.where
-        jrange   = @fetchfrom pid colrange(fetch(r))
-        T,n      = eltype(y), length(y)
-        acc[i] = @spawnat pid mul!(zeros(T,n),fetch(r),view(x,jrange),1,0;global_index=false,threads)
+        r = leaves[i].data.future
+        pid = r.where
+        jrange = @fetchfrom pid colrange(fetch(r))
+        T, n = eltype(y), length(y)
+        acc[i] = @spawnat pid mul!(zeros(T, n), fetch(r), view(x, jrange), 1, 0;
+                                   global_index=false, threads)
     end
     # reduction stage: fetch everybody to worker 1 and sum them up
     for yi in acc
-        axpy!(1,fetch(yi),y)
+        axpy!(1, fetch(yi), y)
     end
     # permute output
-    global_index && invpermute!(y,loc2glob(rtree))
+    global_index && invpermute!(y, loc2glob(rtree))
     return y
 end
 

--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -1,6 +1,6 @@
-abstract type  AbstractHMatrix{T} <: AbstractMatrix{T} end
+abstract type AbstractHMatrix{T} <: AbstractMatrix{T} end
 
-function Base.getindex(H::AbstractHMatrix,i,j)
+function Base.getindex(H::AbstractHMatrix, i::Int, j::Int)
     # NOTE: you may disable `getindex` to avoid having code that will work, but be
     # horribly slow because it falls back to some generic implementation in
     # LinearAlgebra. The downside is that the `show` method, which will usually
@@ -15,25 +15,25 @@ function Base.getindex(H::AbstractHMatrix,i,j)
     `AbstractHMatrix` has fallen back to a generic implementation.
     """
     if ALLOW_GETINDEX[]
-        shift = pivot(H) .-1
-        _getindex(H,i+shift[1],j+shift[2])
+        shift = pivot(H) .- 1
+        _getindex(H, i + shift[1], j + shift[2])
     else
         error(msg)
     end
 end
 
-function _getindex(H,i,j)
-    (i ∈ rowrange(H)) && (j ∈ colrange(H)) || throw(BoundsError(H,(i,j)))
+function _getindex(H::AbstractHMatrix, i::Int, j::Int)
+    (i ∈ rowrange(H)) && (j ∈ colrange(H)) || throw(BoundsError(H, (i, j)))
     acc = zero(eltype(H))
     shift = pivot(H) .- 1
     if hasdata(H)
         il = i - shift[1]
         jl = j - shift[2]
-        acc  += data(H)[il,jl]
+        acc += data(H)[il, jl]
     end
     for child in children(H)
         if (i ∈ rowrange(child)) && (j ∈ colrange(child))
-            acc += _getindex(child,i,j)
+            acc += _getindex(child, i, j)
         end
     end
     return acc
@@ -52,120 +52,49 @@ mutable struct HMatrix{R,T} <: AbstractHMatrix{T}
     data::Union{Matrix{T},RkMatrix{T},Nothing}
     children::Matrix{HMatrix{R,T}}
     parent::HMatrix{R,T}
+    root::HMatrix{R,T}
     # inner constructor which handles `nothing` fields.
-    function HMatrix{R,T}(rowtree,coltree,adm,data,children,parent) where {R,T}
+    function HMatrix{R,T}(rowtree, coltree, adm, parent=nothing, data=nothing, children=nothing) where {R,T}
         if data !== nothing
-            @assert (length(rowtree),length(coltree)) === size(data) "$(length(rowtree)),$(length(coltree)) != $(size(data))"
+            @assert (length(rowtree), length(coltree)) === size(data) "$(length(rowtree)),$(length(coltree)) != $(size(data))"
         end
-        hmat = new{R,T}(rowtree,coltree,adm,data)
-        hmat.children = isnothing(children) ? Matrix{HMatrix{R,T}}(undef,0,0) : children
-        hmat.parent   = isnothing(parent) ? hmat : parent
+        hmat = new{R,T}(rowtree, coltree, adm, data)
+        hmat.children = isnothing(children) ? Matrix{HMatrix{R,T}}(undef, 0, 0) : children
+        hmat.parent = isnothing(parent) ? hmat : parent
+        hmat.root = isnothing(parent) ? hmat : parent.root
         return hmat
     end
 end
 
 # setters and getters (defined for AbstractHMatrix)
-isadmissible(H::AbstractHMatrix)  = H.admissible
-hasdata(H::AbstractHMatrix)       = !isnothing(H.data)
-data(H::AbstractHMatrix)          = H.data
-setdata!(H::AbstractHMatrix,d) = setfield!(H,:data,d)
+isadmissible(H::AbstractHMatrix) = H.admissible
+hasdata(H::AbstractHMatrix) = !isnothing(H.data)
+data(H::AbstractHMatrix) = H.data
+setdata!(H::AbstractHMatrix, d) = setfield!(H, :data, d)
 rowtree(H::AbstractHMatrix) = H.rowtree
 coltree(H::AbstractHMatrix) = H.coltree
+leaves(H::AbstractHMatrix) = H.leaves
 
 cluster_type(::HMatrix{R,T}) where {R,T} = R
 
-Base.getindex(H::HMatrix,::Colon,j) = getcol(H,j)
-
-# getcol for regular matrices
-function getcol!(col,M::Matrix,j)
-    @assert length(col) == size(M,1)
-    copyto!(col,view(M,:,j))
-end
-function getcol!(col,adjM::Adjoint{<:Any,<:Matrix},j)
-    @assert length(col) == size(adjM,1)
-    copyto!(col,view(adjM,:,j))
-end
-
-getcol(M::Matrix,j) = M[:,j]
-getcol(adjM::Adjoint{<:Any,<:Matrix},j) = adjM[:,j]
-
-
-function getcol(H::HMatrix,j::Int)
-    m,n = size(H)
-    T   = eltype(H)
-    col = zeros(T,m)
-    getcol!(col,H,j)
-end
-
-function getcol!(col,H::HMatrix,j::Int)
-    (j ∈ colrange(H)) || throw(BoundsError())
-    piv = pivot(H)
-    _getcol!(col,H,j,piv)
-end
-
-function _getcol!(col,H::HMatrix,j,piv)
-    if hasdata(H)
-        shift        = pivot(H) .- 1
-        jl           = j - shift[2]
-        irange       = rowrange(H) .- (piv[1] - 1)
-        getcol!(view(col,irange),data(H),jl)
-    end
-    for child in children(H)
-        if j ∈ colrange(child)
-            _getcol!(col,child,j,piv)
-        end
-    end
-    return col
-end
-
-Base.getindex(adjH::Adjoint{<:Any,<:HMatrix},::Colon,j) = getcol(adjH,j)
-
-function getcol(adjH::Adjoint{<:Any,<:HMatrix},j::Int)
-    # (j ∈ colrange(adjH)) || throw(BoundsError())
-    m,n = size(adjH)
-    T   = eltype(adjH)
-    col = zeros(T,m)
-    getcol!(col,adjH,j)
-end
-
-function getcol!(col,adjH::Adjoint{<:Any,<:HMatrix},j::Int)
-    piv = pivot(adjH)
-    _getcol!(col,adjH,j,piv)
-end
-
-function _getcol!(col,adjH::Adjoint{<:Any,<:HMatrix},j,piv)
-    if hasdata(adjH)
-        shift        = pivot(adjH) .- 1
-        jl           = j - shift[2]
-        irange       = rowrange(adjH) .- (piv[1] - 1)
-        getcol!(view(col,irange),data(adjH),jl)
-    end
-    for child in children(adjH)
-        if j ∈ colrange(child)
-            _getcol!(col,child,j,piv)
-        end
-    end
-    return col
-end
-
 # Trees interface
 children(H::AbstractHMatrix) = H.children
-children(H::AbstractHMatrix,idxs...) = H.children[idxs]
-parent(H::AbstractHMatrix)   = H.parent
-isleaf(H::AbstractHMatrix)   = isempty(children(H))
-isroot(H::AbstractHMatrix)   = parent(H) === H
+children(H::AbstractHMatrix, idxs...) = H.children[idxs]
+parent(H::AbstractHMatrix) = H.parent
+isleaf(H::AbstractHMatrix) = isempty(children(H))
+isroot(H::AbstractHMatrix) = parent(H) === H
 
 # interface to AbstractTrees. No children is determined by an empty tuple for
 # AbstractTrees.
 AbstractTrees.children(t::AbstractHMatrix) = isleaf(t) ? () : t.children
 AbstractTrees.nodetype(t::AbstractHMatrix) = typeof(t)
 
-rowrange(H::AbstractHMatrix)         = index_range(H.rowtree)
-colrange(H::AbstractHMatrix)         = index_range(H.coltree)
-rowperm(H::AbstractHMatrix)          =  H |> rowtree |> loc2glob
-colperm(H::AbstractHMatrix)          =  H |> coltree |> loc2glob
-pivot(H::AbstractHMatrix)            = (rowrange(H).start,colrange(H).start)
-offset(H::AbstractHMatrix)           = pivot(H) .- 1
+rowrange(H::AbstractHMatrix) = index_range(H.rowtree)
+colrange(H::AbstractHMatrix) = index_range(H.coltree)
+rowperm(H::AbstractHMatrix) = H |> rowtree |> loc2glob
+colperm(H::AbstractHMatrix) = H |> coltree |> loc2glob
+pivot(H::AbstractHMatrix) = (rowrange(H).start, colrange(H).start)
+offset(H::AbstractHMatrix) = pivot(H) .- 1
 
 # Base.axes(H::HMatrix) = rowrange(H),colrange(H)
 Base.size(H::AbstractHMatrix) = length(rowrange(H)), length(colrange(H))
@@ -184,41 +113,41 @@ function compression_ratio(H::HMatrix)
     nr = length(H) # represented entries
     for block in AbstractTrees.Leaves(H)
         data = block.data
-        ns  += num_stored_elements(data)
-   end
-   return nr/ns
+        ns += num_stored_elements(data)
+    end
+    return nr / ns
 end
 
 num_stored_elements(M::Matrix) = length(M)
 
-function Base.show(io::IO,hmat::HMatrix)
-    isclean(hmat) || return print(io,"Dirty HMatrix")
-    print(io,"HMatrix of $(eltype(hmat)) with range $(rowrange(hmat)) × $(colrange(hmat))")
-    _show(io,hmat)
+function Base.show(io::IO, hmat::HMatrix)
+    isclean(hmat) || return print(io, "Dirty HMatrix")
+    print(io, "HMatrix of $(eltype(hmat)) with range $(rowrange(hmat)) × $(colrange(hmat))")
+    _show(io, hmat)
     return io
 end
-Base.show(io::IO,::MIME"text/plain",hmat::HMatrix) = show(io,hmat)
+Base.show(io::IO, ::MIME"text/plain", hmat::HMatrix) = show(io, hmat)
 
-function _show(io,hmat)
+function _show(io, hmat)
     nodes = collect(AbstractTrees.PreOrderDFS(hmat))
     @printf io "\n\t number of nodes in tree: %i" length(nodes)
     leaves = collect(AbstractTrees.Leaves(hmat))
-    sparse_leaves = filter(isadmissible,leaves)
-    dense_leaves  = filter(!isadmissible,leaves)
-    @printf(io,"\n\t number of leaves: %i (%i admissible + %i full)",length(leaves),length(sparse_leaves),
-    length(dense_leaves))
-    rmin,rmax = isempty(sparse_leaves) ? (-1,-1) : extrema(x->rank(x.data),sparse_leaves)
-    @printf(io,"\n\t min rank of sparse blocks : %i",rmin)
-    @printf(io,"\n\t max rank of sparse blocks : %i",rmax)
-    dense_min,dense_max = isempty(dense_leaves) ? (-1,-1) : extrema(x->length(x.data),dense_leaves)
-    @printf(io,"\n\t min length of dense blocks : %i",dense_min)
-    @printf(io,"\n\t max length of dense blocks : %i",dense_max)
-    points_per_leaf = map(length,leaves)
-    @printf(io,"\n\t min number of elements per leaf: %i",minimum(points_per_leaf))
-    @printf(io,"\n\t max number of elements per leaf: %i",maximum(points_per_leaf))
-    depth_per_leaf = map(depth,leaves)
-    @printf(io,"\n\t depth of tree: %i",maximum(depth_per_leaf))
-    @printf(io,"\n\t compression ratio: %f\n",compression_ratio(hmat))
+    sparse_leaves = filter(isadmissible, leaves)
+    dense_leaves = filter(!isadmissible, leaves)
+    @printf(io, "\n\t number of leaves: %i (%i admissible + %i full)", length(leaves), length(sparse_leaves),
+        length(dense_leaves))
+    rmin, rmax = isempty(sparse_leaves) ? (-1, -1) : extrema(x -> rank(x.data), sparse_leaves)
+    @printf(io, "\n\t min rank of sparse blocks : %i", rmin)
+    @printf(io, "\n\t max rank of sparse blocks : %i", rmax)
+    dense_min, dense_max = isempty(dense_leaves) ? (-1, -1) : extrema(x -> length(x.data), dense_leaves)
+    @printf(io, "\n\t min length of dense blocks : %i", dense_min)
+    @printf(io, "\n\t max length of dense blocks : %i", dense_max)
+    points_per_leaf = map(length, leaves)
+    @printf(io, "\n\t min number of elements per leaf: %i", minimum(points_per_leaf))
+    @printf(io, "\n\t max number of elements per leaf: %i", maximum(points_per_leaf))
+    depth_per_leaf = map(depth, leaves)
+    @printf(io, "\n\t depth of tree: %i", maximum(depth_per_leaf))
+    @printf(io, "\n\t compression ratio: %f\n", compression_ratio(hmat))
     return io
 end
 
@@ -230,18 +159,18 @@ global indexing system (see [`HMatrix`](@ref) for more information); otherwise
 the *local* indexing system induced by the row and columns trees are used
 (default).
 """
-Matrix(hmat::HMatrix;global_index=true) = Matrix{eltype(hmat)}(hmat;global_index)
-function Base.Matrix{T}(hmat::HMatrix;global_index) where {T}
-    M = zeros(T,size(hmat)...)
+Matrix(hmat::HMatrix; global_index=true) = Matrix{eltype(hmat)}(hmat; global_index)
+function Base.Matrix{T}(hmat::HMatrix; global_index) where {T}
+    M = zeros(T, size(hmat)...)
     piv = pivot(hmat)
     for block in AbstractTrees.PreOrderDFS(hmat)
         hasdata(block) || continue
         irange = rowrange(block) .- piv[1] .+ 1
         jrange = colrange(block) .- piv[2] .+ 1
-        M[irange,jrange] += Matrix(block.data)
+        M[irange, jrange] += Matrix(block.data)
     end
     if global_index
-        P = PermutedMatrix(M,invperm(rowperm(hmat)),invperm(colperm(hmat)))
+        P = PermutedMatrix(M, invperm(rowperm(hmat)), invperm(colperm(hmat)))
         return Matrix(P)
     else
         return M
@@ -263,143 +192,82 @@ It is assumed that `K` supports `getindex(K,i,j)`, and that comp can be called
 as `comp(K,irange::UnitRange,jrange::UnitRange)` to produce a compressed version
 of `K[irange,jrange]` in the form of an [`RkMatrix`](@ref).
 """
-function assemble_hmat(K,rowtree,coltree;adm=StrongAdmissibilityStd(3),comp=PartialACA(),
-                       global_index=use_global_index(),threads=use_threads(),distributed=false)
-    T  = eltype(K)
+function assemble_hmat(K, rowtree, coltree; adm=StrongAdmissibilityStd(3), comp=PartialACA(),
+    global_index=use_global_index(), threads=use_threads(), distributed=false)
+    T = eltype(K)
+    R = typeof(rowtree)
     if distributed
-        _assemble_hmat_distributed(K,rowtree,coltree;adm,comp,global_index,threads)
+        _assemble_hmat_distributed(K, rowtree, coltree; adm, comp, global_index, threads)
     else
-        # create first the structure. No parellelism used as this should be light.
-        @timeit_debug "initilizing block structure" begin
-            hmat = HMatrix{T}(rowtree,coltree,adm)
-        end
         # if needed permute kernel entries into indexing induced by trees
-        global_index && (K = PermutedMatrix(K,loc2glob(rowtree),loc2glob(coltree)))
-        # now assemble the data in the blocks
+        global_index && (K = PermutedMatrix(K, loc2glob(rowtree), loc2glob(coltree)))
+        # create the root, then recurse
+        parent = nothing
+        root = HMatrix{R,T}(rowtree, coltree, adm(rowtree, coltree), parent)
+        # recurse and build the blocks
         @timeit_debug "assembling hmatrix" begin
-            if threads
-                @info "Assembling HMatrix on $(Threads.nthreads()) threads"
-                _assemble_threads!(hmat,K,comp)
-            else
-                @info "Assembling HMatrix on 1 thread"
-                _assemble_cpu!(hmat,K,comp)
+            nt = threads ? Threads.nthreads() : 1
+            @info "Assembling HMatrix on $nt thread(s)"
+            _assemble_hmat!(root, K, comp, adm, threads)
+        end
+    end
+    root
+end
+
+function assemble_hmat(K::AbstractKernelMatrix; atol=0, rank=typemax(Int), rtol=atol > 0 || rank < typemax(Int) ? 0 : sqrt(eps(Float64)), kwargs...)
+    comp = PartialACA(; rtol, atol, rank)
+    adm = StrongAdmissibilityStd(3)
+    X = rowelements(K)
+    Y = colelements(K)
+    Xclt = ClusterTree(X)
+    Yclt = ClusterTree(Y)
+    assemble_hmat(K, Xclt, Yclt; adm, comp, kwargs...)
+end
+
+"""
+    _assemble_hmat!(hmat,K,comp,adm)
+
+Recursive constructor for [`HMatrix`](@ref) called by [`assemble_hmat`](@ref) to
+assemble data on the leaves of `hmat`.
+"""
+function _assemble_hmat!(H::HMatrix{R,T}, K, comp, adm, threads) where {R,T}
+    # _add_to_indexer!(current_node)
+    X = rowtree(H)
+    Y = coltree(H)
+    @sync begin
+        if (isleaf(X) || isleaf(Y))
+            H.admissible = false
+            @usespawn threads _assemble_dense_block!(H, K)
+        elseif adm(X, Y)
+            H.admissible = true
+            @usespawn threads _assemble_sparse_block!(H, K, comp)
+        else
+            H.admissible = false
+            rows = X.children
+            cols = Y.children
+            children = [HMatrix{R,T}(r, c, false, H) for r in rows, c in cols]
+            H.children = children
+            for child in children
+                @usespawn threads _assemble_hmat!(child, K, comp, adm, threads)
             end
         end
     end
+    return H
 end
 
-function assemble_hmat(K::AbstractKernelMatrix;atol=0,rank=typemax(Int),rtol=atol>0 || rank<typemax(Int) ? 0 : sqrt(eps(Float64)),kwargs...)
-    comp = PartialACA(;rtol,atol,rank)
-    adm  = StrongAdmissibilityStd(3)
-    X    = rowelements(K)
-    Y    = colelements(K)
-    Xclt = ClusterTree(X)
-    Yclt = ClusterTree(Y)
-    assemble_hmat(K,Xclt,Yclt;adm,comp,kwargs...)
+function _assemble_sparse_block!(hmat, K, comp)
+    hmat.data = comp(K, hmat.rowtree, hmat.coltree)
 end
 
-"""
-    HMatrix{T}(rowtree,coltree,adm)
-
-Construct an empty `HMatrix` with `rowtree` and `coltree` using the
-admissibility condition `adm`. This function builds the skeleton for the
-hierarchical matrix, but **does not compute `data`** field in the blocks. See
-[`assemble_hmat`](@ref) for assembling a hierarhical matrix.
-"""
-function HMatrix{T}(rowtree::R, coltree::R, adm) where {R,T}
-    #build root
-    root  = HMatrix{R,T}(rowtree,coltree,false,nothing,nothing,nothing)
-    # recurse
-    _build_block_structure!(adm,root)
-    return root
-end
-
-"""
-    _build_block_structure!(adm_fun,current_node)
-
-Recursive constructor for [`HMatrix`](@ref) block structure. Should not be called directly.
-"""
-function _build_block_structure!(adm, current_node::HMatrix{R,T}) where {R,T}
-    X = current_node.rowtree
-    Y = current_node.coltree
-    if (isleaf(X) || isleaf(Y))
-        current_node.admissible = false
-    elseif adm(X,Y)
-        current_node.admissible = true
-    else
-        current_node.admissible = false
-        row_children = X.children
-        col_children = Y.children
-        children     = [HMatrix{R,T}(r,c,false,nothing,nothing,current_node) for r in row_children, c in col_children]
-        current_node.children = children
-        for child in children
-            _build_block_structure!(adm,child)
-        end
-    end
-    return current_node
-end
-
-"""
-    _assemble_cpu!(hmat::HMatrix,K,comp)
-
-Assemble data on the leaves of `hmat`. The admissible leaves are compressed
-using the compressor `comp`. This function assumes the structure of `hmat` has
-already been intialized, and therefore should not be called directly. See
-[`HMatrix`](@ref) information on constructors.
-"""
-function _assemble_cpu!(hmat,K,comp)
-    if isleaf(hmat) # base case
-        if isadmissible(hmat)
-            _assemble_sparse_block!(hmat,K,comp)
-        else
-            _assemble_dense_block!(hmat,K)
-        end
-    else
-        # recurse on children
-        for child in hmat.children
-            _assemble_cpu!(child,K,comp)
-        end
-    end
-    return hmat
-end
-
-"""
-    _assemble_threads!(hmat::HMatrix,K,comp)
-
-Like [`_assemble_cpu!`](@ref), but uses threads to assemble the leaves. Note
-that the threads are spanwned using `Threads.@spawn`, which means they are
-spawned on the same worker as the caller.
-"""
-function _assemble_threads!(hmat,K,comp)
-    # FIXME: ideally something like `omp for schedule(guided)` should be used here
-    # to avoid spawning too many (small) tasks. In the absece of such scheduling
-    # strategy in julia at the moment (v1.6), we resort to manually limiting the size
-    # of the tasks by directly calling the serial method for blocks which are
-    # smaller than a given length (1000^2 here).
-    blocks = filter_tree(hmat,true) do x
-        (isleaf(x) || length(x)<1000*1000)
-    end
-    sort!(blocks;lt=(x,y)->length(x)<length(y),rev=true)
-    n = length(blocks)
-    @sync for i in 1:n
-        Threads.@spawn _assemble_cpu!(blocks[i],K,comp)
-    end
-    return hmat
-end
-
-function _assemble_sparse_block!(hmat,K,comp)
-    hmat.data = comp(K,hmat.rowtree,hmat.coltree)
-end
-
-function _assemble_dense_block!(hmat,K)
+function _assemble_dense_block!(hmat, K)
     irange = rowrange(hmat)
     jrange = colrange(hmat)
-    hmat.data = K[irange,jrange]
+    hmat.data = K[irange, jrange]
     return hmat
 end
 
 hasdata(adjH::Adjoint{<:Any,<:HMatrix}) = hasdata(adjH.parent)
-data(adjH::Adjoint{<:Any,<:HMatrix}) = adjoint(data(adjH.parent))
+data(adjH::Adjoint{<:Any,<:HMatrix}) = hasdata(adjH) ? adjoint(data(adjH.parent)) : nothing
 children(adjH::Adjoint{<:Any,<:HMatrix}) = adjoint(children(adjH.parent))
 pivot(adjH::Adjoint{<:Any,<:HMatrix}) = reverse(pivot(adjH.parent))
 offset(adjH::Adjoint{<:Any,<:HMatrix}) = pivot(adjH) .- 1
@@ -409,14 +277,14 @@ isleaf(adjH::Adjoint{<:Any,<:HMatrix}) = isleaf(adjH.parent)
 
 Base.size(adjH::Adjoint{<:Any,<:HMatrix}) = reverse(size(adjH.parent))
 
-function Base.show(io::IO,adjH::Adjoint{<:Any,<:HMatrix})
+function Base.show(io::IO, adjH::Adjoint{<:Any,<:HMatrix})
     hmat = parent(adjH)
-    isclean(hmat) || return print(io,"Dirty HMatrix")
-    print(io,"Adjoint HMatrix of $(eltype(hmat)) with range $(rowrange(adjH)) × $(colrange(adjH))")
-    _show(io,hmat)
+    isclean(hmat) || return print(io, "Dirty HMatrix")
+    print(io, "Adjoint HMatrix of $(eltype(hmat)) with range $(rowrange(adjH)) × $(colrange(adjH))")
+    _show(io, hmat)
     return io
 end
-Base.show(io::IO,::MIME"text/plain",adjH::Adjoint{<:Any,<:HMatrix}) = show(io,adjH)
+Base.show(io::IO, ::MIME"text/plain", adjH::Adjoint{<:Any,<:HMatrix}) = show(io, adjH)
 
 """
     struct StrongAdmissibilityStd
@@ -432,13 +300,13 @@ adm(Xnode,Ynode)
 ```
 """
 Base.@kwdef struct StrongAdmissibilityStd
-    eta::Float64=3.0
+    eta::Float64 = 3.0
 end
 
 function (adm::StrongAdmissibilityStd)(left_node, right_node)
-    diam_min = minimum(diameter,(left_node,right_node))
-    dist     = distance(left_node,right_node)
-    return diam_min < adm.eta*dist
+    diam_min = minimum(diameter, (left_node, right_node))
+    dist = distance(left_node, right_node)
+    return diam_min < adm.eta * dist
 end
 
 """
@@ -450,7 +318,7 @@ between them is positive.
 struct WeakAdmissibilityStd
 end
 
-(adm::WeakAdmissibilityStd)(left_node, right_node) = distance(left_node,right_node) > 0
+(adm::WeakAdmissibilityStd)(left_node, right_node) = distance(left_node, right_node) > 0
 
 """
     isclean(H::HMatrix)
@@ -477,58 +345,122 @@ function isclean(H::HMatrix)
     return true
 end
 
-function depth(tree::HMatrix,acc=0)
+function depth(tree::HMatrix, acc=0)
     if isroot(tree)
         return acc
     else
-        depth(parent(tree),acc+1)
+        depth(parent(tree), acc + 1)
     end
 end
 
 function Base.zero(H::HMatrix)
     H0 = deepcopy(H)
-    rmul!(H0,0)
+    rmul!(H0, 0)
     return H0
 end
 
-function compress!(H::HMatrix,comp)
+function compress!(H::HMatrix, comp)
     @assert isclean(H)
     for leaf in AbstractTrees.Leaves(H)
         d = data(leaf)
         if d isa RkMatrix
-            compress!(d,comp)
+            compress!(d, comp)
         end
     end
     return H
 end
 
+Base.getindex(H::HMatrix, ::Colon, j) = getcol(H, j)
+
+function getcol!(col, M::Matrix, j, append::Val{T}=Val(false)) where {T}
+    @assert length(col) == size(M, 1)
+    if T
+        axpy!(true,col,view(M,:,j))
+    else
+        copyto!(col, view(M, :, j))
+    end
+end
+function getcol!(col, adjM::Adjoint{<:Any,<:Matrix}, j, append::Val{T}=Val(false)) where {T}
+    @assert length(col) == size(adjM, 1)
+    if T
+        axpy!(true,col,view(M,:,j))
+    else
+        copyto!(col, view(adjM, :, j))
+    end
+end
+
+getcol(M::Matrix, j) = M[:, j]
+getcol(adjM::Adjoint{<:Any,<:Matrix}, j) = adjM[:, j]
+
+function getcol!(col, H::HMatrix, j::Int, append::Val{T}=Val(false)) where {T}
+    (j ∈ colrange(H)) || throw(BoundsError())
+    piv = pivot(H)
+    _getcol!(col, H, j, piv, append)
+end
+
+function _getcol!(col, H::HMatrix, j, piv, append)
+    if hasdata(H)
+        shift = pivot(H) .- 1
+        jl = j - shift[2]
+        irange = rowrange(H) .- (piv[1] - 1)
+        getcol!(view(col, irange), data(H), jl, append)
+    end
+    for child in children(H)
+        if j ∈ colrange(child)
+            _getcol!(col, child, j, piv, append)
+        end
+    end
+    return col
+end
+
+Base.getindex(adjH::Adjoint{<:Any,<:HMatrix}, ::Colon, j) = getcol(adjH, j)
+
+function getcol!(col, adjH::Adjoint{<:Any,<:HMatrix}, j::Int, append::Val{T}=Val(false)) where {T}
+    piv = pivot(adjH)
+    _getcol!(col, adjH, j, piv, append)
+end
+
+function _getcol!(col, adjH::Adjoint{<:Any,<:HMatrix}, j, piv, append)
+    if hasdata(adjH)
+        shift = pivot(adjH) .- 1
+        jl = j - shift[2]
+        irange = rowrange(adjH) .- (piv[1] - 1)
+        getcol!(view(col, irange), data(adjH), jl, append)
+    end
+    for child in children(adjH)
+        if j ∈ colrange(child)
+            _getcol!(col, child, j, piv, append)
+        end
+    end
+    return col
+end
 
 ############################################################################################
 # Recipes
 ############################################################################################
 @recipe function f(hmat::HMatrix)
     legend --> false
-    grid   --> false
+    grid --> false
     aspect_ratio --> :equal
-    yflip  := true
+    yflip := true
     seriestype := :shape
-    linecolor  --> :black
+    linecolor --> :black
     # all leaves
     for block in AbstractTrees.Leaves(hmat)
         @series begin
             if isadmissible(block)
-                fillcolor    --> :blue
-                seriesalpha  --> 1/compression_ratio(block.data)
+                fillcolor --> :blue
+                seriesalpha --> 1 / compression_ratio(block.data)
             else
-                fillcolor    --> :red
-                seriesalpha  --> 0.3
+                fillcolor --> :red
+                seriesalpha --> 0.3
             end
             pt1 = pivot(block)
             pt2 = pt1 .+ size(block) .- 1
-            y1, y2 = pt1[1],pt2[1]
-            x1, x2 = pt1[2],pt2[2]
+            y1, y2 = pt1[1], pt2[1]
+            x1, x2 = pt1[2], pt2[2]
             # annotations := ((x1+x2)/2,(y1+y2)/2, rank(block.data))
-            [x1,x2,x2,x1,x1],[y1,y1,y2,y2,y1]
+            [x1, x2, x2, x1, x1], [y1, y1, y2, y2, y1]
         end
     end
 end

--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -75,6 +75,7 @@ setdata!(H::AbstractHMatrix, d) = setfield!(H, :data, d)
 rowtree(H::AbstractHMatrix) = H.rowtree
 coltree(H::AbstractHMatrix) = H.coltree
 leaves(H::AbstractHMatrix) = H.leaves
+root(H::AbstractHMatrix) = H.root
 
 cluster_type(::HMatrix{R,T}) where {R,T} = R
 

--- a/src/kernelmatrix.jl
+++ b/src/kernelmatrix.jl
@@ -36,14 +36,14 @@ struct KernelMatrix{Tf,Tx,Ty,T} <: AbstractKernelMatrix{T}
     Y::Ty
 end
 
-Base.size(K::KernelMatrix)                   = length(K.X), length(K.Y)
-Base.getindex(K::KernelMatrix,i::Int,j::Int) =  K.f(K.X[i],K.Y[j])
+Base.size(K::KernelMatrix) = length(K.X), length(K.Y)
+Base.getindex(K::KernelMatrix, i::Int, j::Int) = K.f(K.X[i], K.Y[j])
 
 rowelements(K::KernelMatrix) = K.X
 colelements(K::KernelMatrix) = K.Y
 kernel(K::KernelMatrix) = K.f
 
-function KernelMatrix(f,X,Y)
-    T = Base.promote_op(f,eltype(X),eltype(Y))
-    KernelMatrix{typeof(f),typeof(X),typeof(Y),T}(f,X,Y)
+function KernelMatrix(f, X, Y)
+    T = Base.promote_op(f, eltype(X), eltype(Y))
+    return KernelMatrix{typeof(f),typeof(X),typeof(Y),T}(f, X, Y)
 end

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -23,7 +23,7 @@ function lu!(M::HMatrix, compressor; threads=use_threads())
         _lu!(M, compressor, threads)
     end
     # wrap the result in the LU structure
-    res = @dspawn LU(@R(M), LinearAlgebra.BlasInt[], LinearAlgebra.BlasInt(0))
+    res = @dspawn LU(@R(M), LinearAlgebra.BlasInt[], LinearAlgebra.BlasInt(0)) label = "LU"
     return fetch(res)
 end
 
@@ -51,34 +51,21 @@ lu(M::HMatrix, args...; kwargs...) = lu!(deepcopy(M), args...; kwargs...)
 
 function _lu!(M::HMatrix, compressor, threads)
     if isleaf(M)
-        d = data(M)
-        @assert d isa Matrix
-        @timeit_debug "dense lu factorization" begin
-            lu!(d, NOPIVOT())
-        end
+        @dspawn lu!(data(@RW(M)), NOPIVOT()) label = "Dense LU"
     else
-        @assert !hasdata(M)
         chdM = children(M)
         m, n = size(chdM)
         for i in 1:m
             _lu!(chdM[i, i], compressor, threads)
             for j in (i + 1):n
-                @sync begin
-                    @timeit_debug "ldiv! solution" begin
-                        @dspawn ldiv!(UnitLowerTriangular(@R(chdM[i, i])), @RW(chdM[i, j]),
-                                      compressor)
-                    end
-                    @timeit_debug "rdiv! solution" begin
-                        @dspawn rdiv!(@RW(chdM[j, i]), UpperTriangular(@R(chdM[i, i])),
-                                      compressor)
-                    end
-                end
+                ldiv!(UnitLowerTriangular(chdM[i, i]), chdM[i, j],
+                      compressor)
+                rdiv!(chdM[j, i], UpperTriangular(chdM[i, i]),
+                      compressor)
             end
             for j in (i + 1):m
                 for k in (i + 1):n
-                    @timeit_debug "hmul!" begin
-                        @dspawn hmul!(@RW(chdM[j, k]), @R(chdM[j, i]), @R(chdM[i, k]), -1, 1, compressor)
-                    end
+                    hmul!(chdM[j, k], chdM[j, i], chdM[i, k], -1, 1, compressor)
                 end
             end
         end
@@ -86,10 +73,11 @@ function _lu!(M::HMatrix, compressor, threads)
     return M
 end
 
+# routines needed to solve linear problem as HLU\y
 function ldiv!(A::LU{<:Any,<:HMatrix}, y::AbstractVector; global_index=true)
-    p = A.factors # underlying data
-    ctree = coltree(p)
-    rtree = rowtree(p)
+    H = A.factors # underlying data
+    ctree = coltree(H)
+    rtree = rowtree(H)
     # permute input
     global_index && permute!(y, loc2glob(ctree))
     L, U = A.L, A.U

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -1,13 +1,13 @@
 const NOPIVOT = VERSION >= v"1.7" ? NoPivot : Val{false}
 
-function Base.getproperty(LU::LU{<:Any,<:HMatrix},s::Symbol)
-    H = getfield(LU,:factors) # the underlying hierarchical matrix
+function Base.getproperty(LU::LU{<:Any,<:HMatrix}, s::Symbol)
+    H = getfield(LU, :factors) # the underlying hierarchical matrix
     if s == :L
         return UnitLowerTriangular(H)
     elseif s == :U
         return UpperTriangular(H)
     else
-        return getfield(LU,s)
+        return getfield(LU, s)
     end
 end
 
@@ -17,13 +17,13 @@ end
 Hierarhical LU facotrization of `M`, using `comp` to generate the compressed
 blocks during the multiplication routines.
 """
-function lu!(M::HMatrix,compressor;threads=use_threads())
+function lu!(M::HMatrix, compressor; threads=use_threads())
     # perform the lu decomposition of M in place
     @timeit_debug "lu factorization" begin
-        _lu!(M,compressor,threads)
+        _lu!(M, compressor, threads)
     end
     # wrap the result in the LU structure
-    return LU(M,LinearAlgebra.BlasInt[],LinearAlgebra.BlasInt(0))
+    return LU(M, LinearAlgebra.BlasInt[], LinearAlgebra.BlasInt(0))
 end
 
 """
@@ -32,9 +32,13 @@ end
 
 Hierarhical LU facotrization of `M`, using the `PartialACA(;atol,rtol;rank)` compressor.
 """
-function lu!(M::HMatrix;atol=0,rank=typemax(Int),rtol=atol>0 || rank<typemax(Int) ? 0 : sqrt(eps(Float64)),kwargs...)
-    compressor = PartialACA(atol,rank,rtol)
-    lu!(M,compressor;kwargs...)
+function lu!(M::HMatrix;
+             atol=0,
+             rank=typemax(Int),
+             rtol=atol > 0 || rank < typemax(Int) ? 0 : sqrt(eps(Float64)),
+             kwargs...)
+    compressor = PartialACA(atol, rank, rtol)
+    return lu!(M, compressor; kwargs...)
 end
 
 """
@@ -42,35 +46,37 @@ end
 
 Hierarchical LU factorization. See [`lu!`](@ref) for the available options.
 """
-lu(M::HMatrix,args...;kwargs...) = lu!(deepcopy(M),args...;kwargs...)
+lu(M::HMatrix, args...; kwargs...) = lu!(deepcopy(M), args...; kwargs...)
 
-function _lu!(M::HMatrix,compressor,threads)
+function _lu!(M::HMatrix, compressor, threads)
     if isleaf(M)
         d = data(M)
         @assert d isa Matrix
         @timeit_debug "dense lu factorization" begin
-            lu!(d,NOPIVOT())
+            lu!(d, NOPIVOT())
         end
     else
         @assert !hasdata(M)
         chdM = children(M)
-        m,n = size(chdM)
-        for i=1:m
-            _lu!(chdM[i,i],compressor,threads)
-            for j=i+1:n
+        m, n = size(chdM)
+        for i in 1:m
+            _lu!(chdM[i, i], compressor, threads)
+            for j in (i + 1):n
                 @sync begin
                     @timeit_debug "ldiv! solution" begin
-                        @usespawn threads ldiv!(UnitLowerTriangular(chdM[i,i]),chdM[i,j],compressor)
+                        @usespawn threads ldiv!(UnitLowerTriangular(chdM[i, i]), chdM[i, j],
+                                                compressor)
                     end
                     @timeit_debug "rdiv! solution" begin
-                        @usespawn threads rdiv!(chdM[j,i],UpperTriangular(chdM[i,i]),compressor)
+                        @usespawn threads rdiv!(chdM[j, i], UpperTriangular(chdM[i, i]),
+                                                compressor)
                     end
                 end
             end
-            for j in i+1:m
-                for k in i+1:n
+            for j in (i + 1):m
+                for k in (i + 1):n
                     @timeit_debug "hmul!" begin
-                        hmul!(chdM[j,k],chdM[j,i],chdM[i,k],-1,1,compressor)
+                        hmul!(chdM[j, k], chdM[j, i], chdM[i, k], -1, 1, compressor)
                     end
                 end
             end
@@ -79,19 +85,19 @@ function _lu!(M::HMatrix,compressor,threads)
     return M
 end
 
-function ldiv!(A::LU{<:Any,<:HMatrix},y::AbstractVector;global_index=true)
-    p         = A.factors # underlying data
-    ctree     = coltree(p)
-    rtree     = rowtree(p)
+function ldiv!(A::LU{<:Any,<:HMatrix}, y::AbstractVector; global_index=true)
+    p = A.factors # underlying data
+    ctree = coltree(p)
+    rtree = rowtree(p)
     # permute input
-    global_index && permute!(y,loc2glob(ctree))
-    L,U = A.L, A.U
+    global_index && permute!(y, loc2glob(ctree))
+    L, U = A.L, A.U
     # solve LUx = y through:
     # (a) L(z) = y
     # (b) Ux   = z
-    ldiv!(L,y)
-    ldiv!(U,y)
-    global_index && invpermute!(y,loc2glob(rtree))
+    ldiv!(L, y)
+    ldiv!(U, y)
+    global_index && invpermute!(y, loc2glob(rtree))
     return y
 end
 
@@ -103,19 +109,19 @@ function ldiv!(L::HUnitLowerTriangular, y::AbstractVector)
     else
         @assert !hasdata(H) "only leaves are allowed to have data when using `ldiv`!"
         shift = pivot(H) .- 1
-        chdH  = children(H)
-        m, n   = size(chdH)
+        chdH = children(H)
+        m, n = size(chdH)
         @assert m === n
-        for i = 1:m
-            irows  = colrange(chdH[i,i]) .- shift[2]
-            bi     = view(y, irows)
-            for j = 1:(i - 1)# j<i
-                jrows  = colrange(chdH[i,j]) .- shift[2]
-                bj     = view(y, jrows)
-                _mul131!(bi, chdH[i,j], bj, -1)
+        for i in 1:m
+            irows = colrange(chdH[i, i]) .- shift[2]
+            bi = view(y, irows)
+            for j in 1:(i - 1)# j<i
+                jrows = colrange(chdH[i, j]) .- shift[2]
+                bj = view(y, jrows)
+                _mul131!(bi, chdH[i, j], bj, -1)
             end
             # recursion stage
-            ldiv!(UnitLowerTriangular(chdH[i,i]), bi)
+            ldiv!(UnitLowerTriangular(chdH[i, i]), bi)
         end
     end
     return y
@@ -129,19 +135,19 @@ function ldiv!(U::HUpperTriangular, y::AbstractVector)
     else
         @assert !hasdata(H) "only leaves are allowed to have data when using `ldiv`!"
         shift = pivot(H) .- 1
-        chdH  = children(H)
-        m, n   = size(chdH)
+        chdH = children(H)
+        m, n = size(chdH)
         @assert m === n
-        for i = m:-1:1
-            irows  = colrange(chdH[i,i]) .- shift[2]
-            bi     = view(y, irows)
-            for j = i+1:n # j>i
-                jrows  = colrange(chdH[i,j]) .- shift[2]
-                bj     = view(y, jrows)
-                _mul131!(bi, chdH[i,j], bj, -1)
+        for i in m:-1:1
+            irows = colrange(chdH[i, i]) .- shift[2]
+            bi = view(y, irows)
+            for j in (i + 1):n # j>i
+                jrows = colrange(chdH[i, j]) .- shift[2]
+                bj = view(y, jrows)
+                _mul131!(bi, chdH[i, j], bj, -1)
             end
             # recursion stage
-            ldiv!(UpperTriangular(chdH[i,i]), bi)
+            ldiv!(UpperTriangular(chdH[i, i]), bi)
         end
     end
     return y

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -25,14 +25,14 @@ end
 function Base.size(L::MulLinearOp)
     isnothing(L.R) || (return size(L.R))
     isnothing(L.P) || (return size(L.P))
-    isempty(L.pairs) && (return (0,0))
-    A,B = first(L.pairs)
-    return (size(A,1),size(B,2))
+    isempty(L.pairs) && (return (0, 0))
+    A, B = first(L.pairs)
+    return (size(A, 1), size(B, 2))
 end
 
-function Base.getindex(L::Union{MulLinearOp,Adjoint{<:Any,<:MulLinearOp}},i::Int,j::Int)
+function Base.getindex(L::Union{MulLinearOp,Adjoint{<:Any,<:MulLinearOp}}, i::Int, j::Int)
     if ALLOW_GETINDEX[]
-        getcol(L,j)[i]
+        getcol(L, j)[i]
     else
         error("calling `getindex(L,i,j)` of a `MulLinearOp` has been disabled")
     end
@@ -46,33 +46,33 @@ matrices and `compressor` is a function/functor used in the intermediate stages
 of the multiplication to avoid growing the rank of admissible blocks after
 addition is performed.
 """
-function hmul!(C::T,A::T,B::T,a,b,compressor) where T<:HMatrix
+function hmul!(C::T, A::T, B::T, a, b, compressor) where {T<:HMatrix}
     @assert isroot(C) || !hasdata(parent(C))
-    b == true || rmul!(C,b)
+    b == true || rmul!(C, b)
     dict = Dict{T,Vector{NTuple{2,T}}}()
     @timeit_debug "constructing plan" begin
-        _plan_dict!(dict,C,A,B)
+        _plan_dict!(dict, C, A, B)
     end
     @timeit_debug "executing plan" begin
-        execute!(C,compressor,dict,a,nothing)
+        execute!(C, compressor, dict, a, nothing)
     end
     return C
 end
 
-function _plan_dict!(dict,C::T,A::T,B::T) where {T<:HMatrix}
-    pairs = get!(dict,C,Tuple{T,T}[])
+function _plan_dict!(dict, C::T, A::T, B::T) where {T<:HMatrix}
+    pairs = get!(dict, C, Tuple{T,T}[])
     if isleaf(A) || isleaf(B) || isleaf(C)
-        push!(pairs,(A,B))
+        push!(pairs, (A, B))
     else
-        ni,nj = blocksize(C)
-        _ ,nk = blocksize(A)
+        ni, nj = blocksize(C)
+        _, nk = blocksize(A)
         A_children = children(A)
         B_children = children(B)
         C_children = children(C)
-        for i=1:ni
-            for j=1:nj
-                for k=1:nk
-                    _plan_dict!(dict,C_children[i,j],A_children[i,k],B_children[k,j])
+        for i in 1:ni
+            for j in 1:nj
+                for k in 1:nk
+                    _plan_dict!(dict, C_children[i, j], A_children[i, k], B_children[k, j])
                 end
             end
         end
@@ -81,97 +81,97 @@ function _plan_dict!(dict,C::T,A::T,B::T) where {T<:HMatrix}
 end
 
 # disable `mul` of hierarchial matrices
-function mul!(C::HMatrix,A::HMatrix,B::HMatrix,a::Number,b::Number)
+function mul!(C::HMatrix, A::HMatrix, B::HMatrix, a::Number, b::Number)
     msg = "use `hmul!` to multiply hierarchical matrices"
-    error(msg)
+    return error(msg)
 end
 
-Base.getindex(L::MulLinearOp,::Colon,j::Int) = getcol(L,j)
-Base.getindex(L::Adjoint{<:Any,<:MulLinearOp},::Colon,j::Int) = getcol(L,j)
+Base.getindex(L::MulLinearOp, ::Colon, j::Int) = getcol(L, j)
+Base.getindex(L::Adjoint{<:Any,<:MulLinearOp}, ::Colon, j::Int) = getcol(L, j)
 
-function getcol!(col,L::MulLinearOp,j)
-    m,n = size(L)
-    T  = eltype(L)
+function getcol!(col, L::MulLinearOp, j)
+    m, n = size(L)
+    T = eltype(L)
     # compute j-th column of ∑ Aᵢ Bᵢ
-    for (A,B) in L.pairs
-        m,k = size(A)
-        k,n = size(B)
-        tmp = zeros(T,k)
-        jg   = j + offset(B)[2] # global index on hierarchical matrix B
-        getcol!(tmp,B,jg)
-        _hgemv_recursive!(col,A,tmp,offset(A))
+    for (A, B) in L.pairs
+        m, k = size(A)
+        k, n = size(B)
+        tmp = zeros(T, k)
+        jg = j + offset(B)[2] # global index on hierarchical matrix B
+        getcol!(tmp, B, jg)
+        _hgemv_recursive!(col, A, tmp, offset(A))
     end
     # multiply the columns by a
     a = L.multiplier
-    rmul!(col,a)
+    rmul!(col, a)
     # add R and P (if they exist)
     R = L.R
     if !isnothing(R)
-        getcol!(col,R,j,Val(true))
+        getcol!(col, R, j, Val(true))
     end
     P = L.P
     if !isnothing(P)
-        getcol!(col,P,j,Val(true))
+        getcol!(col, P, j, Val(true))
     end
     return col
 end
 
-function getcol!(col,adjL::Adjoint{<:Any,<:MulLinearOp},j)
-    L     = parent(adjL)
-    T     = eltype(L)
+function getcol!(col, adjL::Adjoint{<:Any,<:MulLinearOp}, j)
+    L = parent(adjL)
+    T = eltype(L)
     # compute j-th column of ∑ adjoint(Bᵢ)*adjoint(Aᵢ)
-    for (A,B) in L.pairs
-        At,Bt = adjoint(A), adjoint(B)
-        tmp = zeros(T,size(At,1))
-        jg  = j + offset(At)[2]
-        getcol!(tmp,At,jg)
-        _hgemv_recursive!(col,Bt,tmp,offset(Bt))
+    for (A, B) in L.pairs
+        At, Bt = adjoint(A), adjoint(B)
+        tmp = zeros(T, size(At, 1))
+        jg = j + offset(At)[2]
+        getcol!(tmp, At, jg)
+        _hgemv_recursive!(col, Bt, tmp, offset(Bt))
     end
     # multiply by a
-    a     = L.multiplier
-    rmul!(col,conj(a))
+    a = L.multiplier
+    rmul!(col, conj(a))
     # add the j-th column of Ct if it has data
-    R     = L.R
+    R = L.R
     if !isnothing(R)
-        getcol!(col,adjoint(R),j,Val(true))
+        getcol!(col, adjoint(R), j, Val(true))
     end
     P = L.P
     if !isnothing(P)
-        getcol!(col,adjoint(P),j,Val(true))
+        getcol!(col, adjoint(P), j, Val(true))
     end
     return col
 end
 
-function execute!(C::HMatrix,compressor,dict,a,R)
-    execute_node!(C,compressor,dict,a,R)
+function execute!(C::HMatrix, compressor, dict, a, R)
+    execute_node!(C, compressor, dict, a, R)
     shift = pivot(C) .- 1
     for chd in children(C)
-        irange   = rowrange(chd) .- shift[1]
-        jrange   = colrange(chd) .- shift[2]
+        irange = rowrange(chd) .- shift[1]
+        jrange = colrange(chd) .- shift[2]
         Rp = data(C)
         # Rv = (!isroot(C) && hasdata(C)) ? RkMatrix(Rp.A[irange,:],Rp.B[jrange,:]) : nothing
-        Rv = (!isroot(C) && hasdata(C)) ? view(Rp,irange,jrange) : nothing
-        execute!(chd,compressor,dict,a,Rv)
+        Rv = (!isroot(C) && hasdata(C)) ? view(Rp, irange, jrange) : nothing
+        execute!(chd, compressor, dict, a, Rv)
     end
-    isleaf(C) || (setdata!(C,nothing))
+    isleaf(C) || (setdata!(C, nothing))
     return C
 end
 
 # non-recursive execution
-function execute_node!(C::HMatrix,compressor,dict,a,R)
+function execute_node!(C::HMatrix, compressor, dict, a, R)
     T = typeof(C)
-    pairs = get!(dict,C,Tuple{T,T}[])
+    pairs = get!(dict, C, Tuple{T,T}[])
     isnothing(R) && isempty(pairs) && (return C)
     if isleaf(C) && !isadmissible(C)
         d = data(C)
-        for (A,B) in dict[C]
-            _mul_dense!(d,A,B,a)
+        for (A, B) in dict[C]
+            _mul_dense!(d, A, B, a)
         end
-        isnothing(R) || axpy!(true,R,d)
+        isnothing(R) || axpy!(true, R, d)
     else
-        L = MulLinearOp(data(C),R,pairs,a)
+        L = MulLinearOp(data(C), R, pairs, a)
         @timeit_debug "compressing" R = compressor(L)
-        setdata!(C,R)
+        setdata!(C, R)
     end
     return C
 end
@@ -184,7 +184,7 @@ Multiplication when the target is a dense matrix. The numbering system in the fo
 3 --> HMatrix (hierarchical)
 =#
 
-function _mul_dense!(C::Matrix,A,B,a)
+function _mul_dense!(C::Matrix, A, B, a)
     Adata = isleaf(A) ? A.data : A
     Bdata = isleaf(B) ? B.data : B
     if Adata isa HMatrix
@@ -212,15 +212,26 @@ function _mul_dense!(C::Matrix,A,B,a)
     end
 end
 
-_mul111!(C::Union{Matrix,SubArray,Adjoint},A::Union{Matrix,SubArray,Adjoint},B::Union{Matrix,SubArray,Adjoint},a::Number) = mul!(C,A,B,a,true)
+function _mul111!(C::Union{Matrix,SubArray,Adjoint},
+                  A::Union{Matrix,SubArray,Adjoint},
+                  B::Union{Matrix,SubArray,Adjoint},
+                  a::Number)
+    return mul!(C, A, B, a, true)
+end
 
-function _mul112!(C::Union{Matrix,SubArray,Adjoint}, M::Union{Matrix,SubArray,Adjoint}, R::RkMatrix, a::Number)
+function _mul112!(C::Union{Matrix,SubArray,Adjoint},
+                  M::Union{Matrix,SubArray,Adjoint},
+                  R::RkMatrix,
+                  a::Number)
     buffer = M * R.A
     _mul111!(C, buffer, R.Bt, a)
     return C
 end
 
-function _mul113!(C::Union{Matrix,SubArray,Adjoint}, M::Union{Matrix,SubArray,Adjoint}, H::HMatrix, a::Number)
+function _mul113!(C::Union{Matrix,SubArray,Adjoint},
+                  M::Union{Matrix,SubArray,Adjoint},
+                  H::HMatrix,
+                  a::Number)
     T = eltype(C)
     if hasdata(H)
         mat = data(H)
@@ -233,19 +244,22 @@ function _mul113!(C::Union{Matrix,SubArray,Adjoint}, M::Union{Matrix,SubArray,Ad
         end
     end
     for child in children(H)
-        shift  = pivot(H) .- 1
+        shift = pivot(H) .- 1
         irange = rowrange(child) .- shift[1]
         jrange = colrange(child) .- shift[2]
-        Cview  = @views C[:, jrange]
-        Mview  = @views M[:, irange]
+        Cview = @views C[:, jrange]
+        Mview = @views M[:, irange]
         _mul113!(Cview, Mview, child, a)
     end
     return C
 end
 
-function _mul121!(C::Union{Matrix,SubArray,Adjoint}, R::RkMatrix, M::Union{Matrix,SubArray,Adjoint}, a::Number)
+function _mul121!(C::Union{Matrix,SubArray,Adjoint},
+                  R::RkMatrix,
+                  M::Union{Matrix,SubArray,Adjoint},
+                  a::Number)
     buffer = R.Bt * M
-    _mul111!(C, R.A, buffer, a)
+    return _mul111!(C, R.A, buffer, a)
 end
 
 function _mul122!(C::Union{Matrix,SubArray,Adjoint}, R::RkMatrix, S::RkMatrix, a::Number)
@@ -265,7 +279,10 @@ function _mul123!(C::Union{Matrix,SubArray,Adjoint}, R::RkMatrix, H::HMatrix, a:
     return C
 end
 
-function _mul131!(C::Union{Matrix,SubArray,Adjoint}, H::HMatrix, M::Union{Matrix,SubArray,Adjoint}, a::Number)
+function _mul131!(C::Union{Matrix,SubArray,Adjoint},
+                  H::HMatrix,
+                  M::Union{Matrix,SubArray,Adjoint},
+                  a::Number)
     if isleaf(H)
         mat = data(H)
         if mat isa Matrix
@@ -277,21 +294,21 @@ function _mul131!(C::Union{Matrix,SubArray,Adjoint}, H::HMatrix, M::Union{Matrix
         end
     end
     for child in children(H)
-        shift  = pivot(H) .- 1
+        shift = pivot(H) .- 1
         irange = rowrange(child) .- shift[1]
         jrange = colrange(child) .- shift[2]
-        Cview  = view(C, irange, :)
-        Mview  = view(M, jrange, :)
+        Cview = view(C, irange, :)
+        Mview = view(M, jrange, :)
         _mul131!(Cview, child, Mview, a)
     end
     return C
 end
 
 function _mul132!(C::Union{Matrix,SubArray,Adjoint}, H::HMatrix, R::RkMatrix, a::Number)
-    T = promote_type(eltype(H),eltype(R))
+    T = promote_type(eltype(H), eltype(R))
     buffer = zeros(T, size(H, 1), size(R.A, 2))
-    _mul131!(buffer,H,R.A,1)
-    _mul111!(C, buffer, R.Bt, a,)
+    _mul131!(buffer, H, R.A, 1)
+    _mul111!(C, buffer, R.Bt, a)
     return C
 end
 
@@ -302,18 +319,22 @@ end
 ############################################################################################
 
 # 1.2.1
-function mul!(y::AbstractVector,R::RkMatrix,x::AbstractVector,a::Number,b::Number)
+function mul!(y::AbstractVector, R::RkMatrix, x::AbstractVector, a::Number, b::Number)
     # tmp = R.Bt*x
-    tmp = mul!(R.buffer,adjoint(R.B),x)
-    mul!(y,R.A,tmp,a,b)
+    tmp = mul!(R.buffer, adjoint(R.B), x)
+    return mul!(y, R.A, tmp, a, b)
 end
 
 # 1.2.1
-function mul!(y::AbstractVector,adjR::Adjoint{<:Any,<:RkMatrix},x::AbstractVector,a::Number,b::Number)
+function mul!(y::AbstractVector,
+              adjR::Adjoint{<:Any,<:RkMatrix},
+              x::AbstractVector,
+              a::Number,
+              b::Number)
     R = parent(adjR)
     # tmp = R.At*x
-    tmp = mul!(R.buffer,adjoint(R.A),x)
-    mul!(y,R.B,tmp,a,b)
+    tmp = mul!(R.buffer, adjoint(R.A), x)
+    return mul!(y, R.B, tmp, a, b)
 end
 
 # 1.3.1
@@ -322,25 +343,30 @@ end
 
 Perform `y <-- H*x*a + y*b` in place.
 """
-function mul!(y::AbstractVector,A::HMatrix,x::AbstractVector,a::Number=1,b::Number=0;
-                            global_index=use_global_index(),threads=use_threads())
+function mul!(y::AbstractVector,
+              A::HMatrix,
+              x::AbstractVector,
+              a::Number=1,
+              b::Number=0;
+              global_index=use_global_index(),
+              threads=use_threads())
     # since the HMatrix represents A = inv(Pr)*H*Pc, where Pr and Pc are row and column
     # permutations, we need first to rewrite C <-- b*C + a*(inv(Pr)*H*Pc)*B as
     # C <-- inv(Pr)*(b*Pr*C + a*H*(Pc*B)). Following this rewrite, the
     # multiplication is performed by first defining B <-- Pc*B, and C <--
     # Pr*C, doing the multiplication with the permuted entries, and then
     # permuting the result  back C <-- inv(Pr)*C at the end.
-    ctree     = coltree(A)
-    rtree     = rowtree(A)
+    ctree = coltree(A)
+    rtree = rowtree(A)
     # permute input
     if global_index
-        x         = x[colperm(A)]
-        y         = permute!(y,rowperm(A))
-        rmul!(x,a) # multiply in place since this is a new copy, so does not mutate exterior x
+        x = x[colperm(A)]
+        y = permute!(y, rowperm(A))
+        rmul!(x, a) # multiply in place since this is a new copy, so does not mutate exterior x
     elseif a != 1
-        x = a*x # new copy of x since we should not mutate the external x in mul!
+        x = a * x # new copy of x since we should not mutate the external x in mul!
     end
-    iszero(b) ? fill!(y,zero(eltype(y))) : rmul!(y,b)
+    iszero(b) ? fill!(y, zero(eltype(y))) : rmul!(y, b)
     # offset in case A is not indexed starting at (1,1); e.g. A is not the root
     # of and HMatrix
     offset = pivot(A) .- 1
@@ -357,22 +383,23 @@ function mul!(y::AbstractVector,A::HMatrix,x::AbstractVector,a::Number=1,b::Numb
         #    Right now the hilbert partition is chosen by default without proper
         #    testing.
         @timeit_debug "partitioning leaves" begin
-            haskey(CACHED_PARTITIONS,A) || hilbert_partition(A,Threads.nthreads(),_cost_gemv)
+            haskey(CACHED_PARTITIONS, A) ||
+                hilbert_partition(A, Threads.nthreads(), _cost_gemv)
             # haskey(CACHED_PARTITIONS,A) || col_partition(A,Threads.nthreads(),_cost_gemv)
             # haskey(CACHED_PARTITIONS,A) || row_partition(A,Threads.nthreads(),_cost_gemv)
         end
         @timeit_debug "threaded multiplication" begin
             p = CACHED_PARTITIONS[A]
-            _hgemv_static_partition!(y,x,p.partition,offset)
+            _hgemv_static_partition!(y, x, p.partition, offset)
             # _hgemv_threads!(y,x,p.partition,offset)  # threaded implementation
         end
     else
         @timeit_debug "serial multiplication" begin
-            _hgemv_recursive!(y,A,x,offset) # serial implementation
+            _hgemv_recursive!(y, A, x, offset) # serial implementation
         end
     end
     # permute output
-    global_index && invpermute!(y,rowperm(A))
+    global_index && invpermute!(y, rowperm(A))
     return y
 end
 
@@ -385,74 +412,75 @@ rowrange(A) - offset[1]` and `J = rowrange(B) - offset[2]`.
 The `offset` argument is used on the caller side to signal if the original
 hierarchical matrix had a `pivot` other than `(1,1)`.
 """
-function _hgemv_recursive!(C::AbstractVector,A::Union{HMatrix,Adjoint{<:Any,<:HMatrix}},B::AbstractVector,offset)
+function _hgemv_recursive!(C::AbstractVector, A::Union{HMatrix,Adjoint{<:Any,<:HMatrix}},
+                           B::AbstractVector, offset)
     T = eltype(A)
     if isleaf(A)
         irange = rowrange(A) .- offset[1]
         jrange = colrange(A) .- offset[2]
-        d   = data(A)
+        d = data(A)
         if T <: SMatrix
             # FIXME: there is bug with gemv and static arrays, so we convert
             # them to matrices of n × 1
             # (https://github.com/JuliaArrays/StaticArrays.jl/issues/966#issuecomment-943679214).
-            mul!(view(C,irange,1:1),d,view(B,jrange,1:1),1,1)
+            mul!(view(C, irange, 1:1), d, view(B, jrange, 1:1), 1, 1)
         else
             # C and B are the "global" vectors handled by the caller, so a view
             # is needed.
-            mul!(view(C,irange),d,view(B,jrange),1,1)
+            mul!(view(C, irange), d, view(B, jrange), 1, 1)
         end
     else
         for block in children(A)
-            _hgemv_recursive!(C,block,B,offset)
+            _hgemv_recursive!(C, block, B, offset)
         end
     end
     return C
 end
 
-function _hgemv_threads!(C::AbstractVector,B::AbstractVector,partition,offset)
-    nt        = Threads.nthreads()
+function _hgemv_threads!(C::AbstractVector, B::AbstractVector, partition, offset)
+    nt = Threads.nthreads()
     # make `nt` copies of C and run in parallel
-    Cthreads  = [zero(C) for _ in 1:nt]
+    Cthreads = [zero(C) for _ in 1:nt]
     @sync for p in partition
         for block in p
             Threads.@spawn begin
                 id = Threads.threadid()
-                _hgemv_recursive!(Cthreads[id],block,B,offset)
+                _hgemv_recursive!(Cthreads[id], block, B, offset)
             end
         end
     end
     # reduce
     for Ct in Cthreads
-        axpy!(1,Ct,C)
+        axpy!(1, Ct, C)
     end
     return C
 end
 
-function _hgemv_static_partition!(C::AbstractVector,B::AbstractVector,partition,offset)
+function _hgemv_static_partition!(C::AbstractVector, B::AbstractVector, partition, offset)
     # create a lock for the reduction step
     T = eltype(C)
     mutex = ReentrantLock()
-    np    = length(partition)
-    nt    = Threads.nthreads()
-    Cthreads  = [zero(C) for _ in 1:nt]
+    np = length(partition)
+    nt = Threads.nthreads()
+    Cthreads = [zero(C) for _ in 1:nt]
     @sync for n in 1:np
         Threads.@spawn begin
-            id     = Threads.threadid()
+            id = Threads.threadid()
             leaves = partition[n]
-            Cloc   = Cthreads[id]
+            Cloc = Cthreads[id]
             for leaf in leaves
                 irange = rowrange(leaf) .- offset[1]
                 jrange = colrange(leaf) .- offset[2]
-                data   = leaf.data
+                data = leaf.data
                 if T <: SVector
-                    mul!(view(Cloc,irange,1:1),data,view(B,jrange,1:1),1,1)
+                    mul!(view(Cloc, irange, 1:1), data, view(B, jrange, 1:1), 1, 1)
                 else
-                    mul!(view(Cloc,irange),data,view(B,jrange),1,1)
+                    mul!(view(Cloc, irange), data, view(B, jrange), 1, 1)
                 end
             end
             # reduction
             lock(mutex) do
-                axpy!(1,Cloc,C)
+                return axpy!(1, Cloc, C)
             end
         end
     end
@@ -486,10 +514,10 @@ end
 A proxy for the computational cost of a matrix/vector product.
 """
 function _cost_gemv(R::RkMatrix)
-    rank(R)*sum(size(R))
+    return rank(R) * sum(size(R))
 end
 function _cost_gemv(M::Matrix)
-    length(M)
+    return length(M)
 end
 function _cost_gemv(H::HMatrix)
     acc = 0.0

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -160,11 +160,11 @@ end
 # non-recursive execution
 function execute_node!(C::HMatrix, compressor, dict, a, R)
     T = typeof(C)
-    pairs = get!(dict, C, Tuple{T,T}[])
+    pairs = get(dict, C, Tuple{T,T}[])
     isnothing(R) && isempty(pairs) && (return C)
     if isleaf(C) && !isadmissible(C)
         d = data(C)
-        for (A, B) in dict[C]
+        for (A, B) in pairs
             _mul_dense!(d, A, B, a)
         end
         isnothing(R) || axpy!(true, R, d)

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -15,8 +15,8 @@ recompression of intermediate computations.
 """
 struct MulLinearOp{R,T,S} <: AbstractMatrix{T}
     R::Union{RkMatrix{T},Nothing}
-    P::Union{RkMatrixBlockView{T},Nothing}
-    # P::Union{RkMatrix{T},Nothing}
+    # P::Union{RkMatrixBlockView{T},Nothing}
+    P::Union{RkMatrix{T},Nothing}
     pairs::Vector{NTuple{2,HMatrix{R,T}}}
     multiplier::S
 end
@@ -52,36 +52,44 @@ function hmul!(C::T, A::T, B::T, a, b, compressor) where {T<:HMatrix}
     _plan_dict!(dict, C, A, B)
     # execute the plan
     b == true || rmul!(C, b)
-    return _hmul!(C, compressor, dict, a, true)
+    return _hmul!(C, compressor, dict, a)
 end
 
-function _hmul!(C::T, compressor, dict, a, root) where {T<:HMatrix}
+function _hmul!(C::T, compressor, dict, a) where {T<:HMatrix}
     pairs = get(dict, C, Tuple{T,T}[])
-    # update the data in C if needed
-    @dspawn begin
-        @RW C
-        @R parent(C)
-        @R pairs
-        R = _parent_data_restriction(C,root)
-        if !isnothing(R) || !isempty(pairs)
-            if isleaf(C) && !isadmissible(C)
+    if isleaf(C)
+        if isadmissible(C)
+            @dspawn begin
+                @RW C
+                @R pairs
+                L = MulLinearOp(data(C), nothing, pairs, a)
+                R = compressor(L)
+                setdata!(C, R)
+            end label="sparse mul"
+        else
+            @dspawn begin
+                @RW C
+                @R pairs
                 d = data(C)
                 for (A, B) in pairs
                     _mul_dense!(d, A, B, a)
                 end
-                isnothing(R) || axpy!(true, R, d)
-            else
-                L = MulLinearOp(data(C), R, pairs, a)
-                R = compressor(L)
-                setdata!(C, R)
-            end
+            end label="dense mul"
         end
-    end label="hmul"
-    # move to children
-    for chd in children(C)
-        _hmul!(chd, compressor, dict, a, false)
+    elseif !isempty(pairs)
+        # internal node: compute low rank approximation
+        Rtask = @dspawn begin
+            @R pairs
+            L = MulLinearOp(nothing, nothing, pairs, a)
+            compressor(L)
+        end label="flush"
+        # move low rank data to leaves
+        add_to_leaves!(C,Rtask,compressor)
     end
-    isleaf(C) || @dspawn setdata!(@W(C), nothing) label="clear parent"
+    # continue with children of C
+    for chd in children(C)
+        _hmul!(chd, compressor, dict, a)
+    end
     return C
 end
 
@@ -106,8 +114,8 @@ function _plan_dict!(dict, C::T, A::T, B::T) where {T<:HMatrix}
     return dict
 end
 
-function _parent_data_restriction(C,root)
-    P  = parent(C)
+function _parent_data_restriction(C, root)
+    P = parent(C)
     Rp = data(P)
     if root || isnothing(Rp)
         return nothing
@@ -116,10 +124,49 @@ function _parent_data_restriction(C,root)
         shift = pivot(P) .- 1
         irange = rowrange(C) .- shift[1]
         jrange = colrange(C) .- shift[2]
-        return view(Rp, irange, jrange)
-        # return RkMatrix(Rp.A[irange, :], Rp.B[jrange, :])
+        # return view(Rp, irange, jrange)
+        return RkMatrix(Rp.A[irange, :], Rp.B[jrange, :])
     end
 end
+
+"""
+    add_to_leaves(H::HMatrix,R,compressor)
+
+Add `R` to the leaves of `H`.
+"""
+function add_to_leaves!(H::HMatrix, Rtask, compressor)
+    shift = pivot(H) .- 1
+    _add_to_leaves!(H,Rtask,compressor,shift)
+end
+function _add_to_leaves!(node,Rtask,compressor,shift)
+    S = typeof(node)
+    T = eltype(node)
+    if isleaf(node)
+        @dspawn begin
+            @RW node
+            R = fetch(Rtask)::RkMatrix{T}
+            irange = rowrange(node) .- shift[1]
+            jrange = colrange(node) .- shift[2]
+            Rv = RkMatrix(R.A[irange, :], R.B[jrange, :])
+            # Rv = view(R,irange,jrange)
+            if isadmissible(node)
+                Rl= data(node)::RkMatrix{T}
+                L = MulLinearOp(Rl, Rv, Tuple{S,S}[], true)
+                node.data = compressor(L)
+            else
+                M = data(node)::Matrix{T}
+                axpy!(true, Rv, M)
+            end
+        end label="add to leaves"
+    else
+        for child in children(node)
+            _add_to_leaves!(child,Rtask,compressor,shift)
+        end
+    end
+    return node
+end
+
+
 
 # disable `mul` of hierarchial matrices
 function mul!(C::HMatrix, A::HMatrix, B::HMatrix, a::Number, b::Number)

--- a/src/partitions.jl
+++ b/src/partitions.jl
@@ -25,6 +25,7 @@ const CACHED_PARTITIONS = WeakKeyDict{HMatrix,Partition}()
 
 Base.hash(A::AbstractHMatrix,h::UInt) = hash(objectid(A),h)
 Base.:(==)(A::AbstractHMatrix,B::AbstractHMatrix) = A === B
+Base.isequal(A::AbstractHMatrix,B::AbstractHMatrix) = A === B
 
 """
     build_sequence_partition(seq,nq,cost,nmax)

--- a/src/partitions.jl
+++ b/src/partitions.jl
@@ -23,9 +23,9 @@ recompute the partition for each matrix/vector product.
 """
 const CACHED_PARTITIONS = WeakKeyDict{HMatrix,Partition}()
 
-Base.hash(A::AbstractHMatrix,h::UInt) = hash(objectid(A),h)
-Base.:(==)(A::AbstractHMatrix,B::AbstractHMatrix) = A === B
-Base.isequal(A::AbstractHMatrix,B::AbstractHMatrix) = A === B
+Base.hash(A::AbstractHMatrix, h::UInt) = hash(objectid(A), h)
+Base.:(==)(A::AbstractHMatrix, B::AbstractHMatrix) = A === B
+Base.isequal(A::AbstractHMatrix, B::AbstractHMatrix) = A === B
 
 """
     build_sequence_partition(seq,nq,cost,nmax)
@@ -34,7 +34,7 @@ Partition the sequence `seq` into `nq` contiguous subsequences with a maximum of
 cost of `nmax` per set. Note that if `nmax` is too small, this may not be
 possible (see [`has_partition`](@ref)).
 """
-function build_sequence_partition(seq,np,cost,cmax)
+function build_sequence_partition(seq, np, cost, cmax)
     acc = 0
     partition = [empty(seq) for _ in 1:np]
     k = 1
@@ -43,11 +43,11 @@ function build_sequence_partition(seq,np,cost,cmax)
         acc += c
         if acc > cmax
             k += 1
-            push!(partition[k],el)
+            push!(partition[k], el)
             acc = c
             @assert k <= np "unable to build sequence partition. Value of  `cmax` may be too small."
         else
-            push!(partition[k],el)
+            push!(partition[k], el)
         end
     end
     return partition
@@ -60,17 +60,17 @@ Find an approximation to the cost of an optimal partitioning of `seq` into `nq`
 contiguous segments. The optimal cost is the smallest number `cmax` such that
 `has_partition(seq,nq,cost,cmax)` returns `true`.
 """
-function find_optimal_cost(seq,np,cost=identity,tol=1)
-    lbound = maximum(cost,seq) |> Float64
-    ubound = sum(cost,seq)     |> Float64
-    guess  = (lbound+ubound)/2
+function find_optimal_cost(seq, np, cost=identity, tol=1)
+    lbound = Float64(maximum(cost, seq))
+    ubound = Float64(sum(cost, seq))
+    guess = (lbound + ubound) / 2
     while ubound - lbound ≥ tol
-        if has_partition(seq,np,guess,cost)
+        if has_partition(seq, np, guess, cost)
             ubound = guess
         else
             lbound = guess
         end
-        guess  = (lbound+ubound)/2
+        guess = (lbound + ubound) / 2
     end
     return ubound
 end
@@ -86,9 +86,9 @@ which minimizes the maximum `cost` over all possible partitions of `seq` into
 The generated partition is optimal up to a tolerance `tol`; for integer valued
 `cost`, setting `tol=1` means the partition is optimal.
 """
-function find_optimal_partition(seq,np,cost=(x)->1,tol=1)
-    cmax = find_optimal_cost(seq,np,cost,tol)
-    p = build_sequence_partition(seq,np,cost,cmax)
+function find_optimal_partition(seq, np, cost=(x) -> 1, tol=1)
+    cmax = find_optimal_cost(seq, np, cost, tol)
+    p = build_sequence_partition(seq, np, cost, cmax)
     return p
 end
 
@@ -98,9 +98,9 @@ end
 Given a vector `v`, determine whether or not a partition into `np` segments is
 possible where the `cost` of each partition does not exceed `cmax`.
 """
-function has_partition(seq,np,cmax,cost=identity)
+function has_partition(seq, np, cmax, cost=identity)
     acc = 0
-    k   = 1
+    k = 1
     for el in seq
         c = cost(el)
         acc += c
@@ -120,63 +120,63 @@ Partiotion the leaves of `H` into `np` sequences of approximate equal cost (as
 determined by the `cost` function) while also trying to maximize the locality of
 each partition.
 """
-function hilbert_partition(H::HMatrix,np=Threads.nthreads(),cost=_cost_gemv)
+function hilbert_partition(H::HMatrix, np=Threads.nthreads(), cost=_cost_gemv)
     # the hilbert curve will be indexed from (0,0) × (N-1,N-1), so set N to be
     # the smallest power of two larger than max(m,n), where m,n = size(H)
-    m,n = size(H)
-    N   = max(m,n)
-    N   = nextpow(2,N)
+    m, n = size(H)
+    N = max(m, n)
+    N = nextpow(2, N)
     # sort the leaves by their hilbert index
-    leaves = AbstractTrees.Leaves(H) |> collect
+    leaves = collect(AbstractTrees.Leaves(H))
     hilbert_indices = map(leaves) do leaf
         # use the center of the leaf as a cartesian index
-        i,j = pivot(leaf) .- 1 .+ size(leaf) .÷ 2
-        hilbert_cartesian_to_linear(N,i,j)
+        i, j = pivot(leaf) .- 1 .+ size(leaf) .÷ 2
+        return hilbert_cartesian_to_linear(N, i, j)
     end
     p = sortperm(hilbert_indices)
-    permute!(leaves,p)
+    permute!(leaves, p)
     # now compute a quasi-optimal partition of leaves based `cost_mv`
-    cmax      = find_optimal_cost(leaves,np,cost,1)
-    _partition = build_sequence_partition(leaves,np,cost,cmax)
-    partition  = Partition(_partition,:hilbert)
-    push!(CACHED_PARTITIONS,H=>partition)
+    cmax = find_optimal_cost(leaves, np, cost, 1)
+    _partition = build_sequence_partition(leaves, np, cost, cmax)
+    partition = Partition(_partition, :hilbert)
+    push!(CACHED_PARTITIONS, H => partition)
     return partition
 end
 
 # TODO: benchmark the different partitioning strategies for gemv. Is the hilber
 # partition really faster than the simpler alternatives (row partition, col partition)?
-function row_partition(H::HMatrix,np=Threads.nthreads(),cost=_cost_gemv)
+function row_partition(H::HMatrix, np=Threads.nthreads(), cost=_cost_gemv)
     # sort the leaves by their row index
-    leaves = filter_tree(x -> isleaf(x),H)
+    leaves = filter_tree(x -> isleaf(x), H)
     row_indices = map(leaves) do leaf
         # use the center of the leaf as a cartesian index
-        i,j = pivot(leaf)
+        i, j = pivot(leaf)
         return i
     end
     p = sortperm(row_indices)
-    permute!(leaves,p)
+    permute!(leaves, p)
     # now compute a quasi-optimal partition of leaves based `cost_mv`
-    cmax = find_optimal_cost(leaves,np,cost,1)
-    _partition = build_sequence_partition(leaves,np,cost,cmax)
-    partition  = Partition(_partition,:row)
-    push!(CACHED_PARTITIONS,H=>partition)
+    cmax = find_optimal_cost(leaves, np, cost, 1)
+    _partition = build_sequence_partition(leaves, np, cost, cmax)
+    partition = Partition(_partition, :row)
+    push!(CACHED_PARTITIONS, H => partition)
     return partition
 end
 
-function col_partition(H::HMatrix,np=Threads.nthreads(),cost=_cost_gemv)
+function col_partition(H::HMatrix, np=Threads.nthreads(), cost=_cost_gemv)
     # sort the leaves by their row index
-    leaves = filter_tree(x -> isleaf(x),H)
+    leaves = filter_tree(x -> isleaf(x), H)
     row_indices = map(leaves) do leaf
         # use the center of the leaf as a cartesian index
-        i,j = pivot(leaf)
+        i, j = pivot(leaf)
         return j
     end
     p = sortperm(row_indices)
-    permute!(leaves,p)
+    permute!(leaves, p)
     # now compute a quasi-optimal partition of leaves based `cost_mv`
-    cmax = find_optimal_cost(leaves,np,cost,1)
-    _partition = build_sequence_partition(leaves,np,cost,cmax)
-    partition  = Partition(_partition,:col)
-    push!(CACHED_PARTITIONS,H=>partition)
+    cmax = find_optimal_cost(leaves, np, cost, 1)
+    _partition = build_sequence_partition(leaves, np, cost, cmax)
+    partition = Partition(_partition, :col)
+    push!(CACHED_PARTITIONS, H => partition)
     return partition
 end

--- a/src/rkmatrix.jl
+++ b/src/rkmatrix.jl
@@ -11,57 +11,58 @@ mutable struct RkMatrix{T} <: AbstractMatrix{T}
     A::Matrix{T}
     B::Matrix{T}
     buffer::Vector{T} # used for gemv routines to avoid allocations
-    function RkMatrix(A::Matrix{T},B::Matrix{T}) where {T}
-        @assert size(A,2) == size(B,2) "second dimension of `A` and `B` must match"
-        m,r = size(A)
-        n  = size(B,1)
-        if  r*(m+n) >= m*n
+    function RkMatrix(A::Matrix{T}, B::Matrix{T}) where {T}
+        @assert size(A, 2) == size(B, 2) "second dimension of `A` and `B` must match"
+        m, r = size(A)
+        n = size(B, 1)
+        if r * (m + n) >= m * n
             @debug "Inefficient RkMatrix:" size(A) size(B)
             # error("Inefficient RkMatrix")
         end
-        buffer = Vector{T}(undef,r)
-        new{T}(A,B,buffer)
+        buffer = Vector{T}(undef, r)
+        return new{T}(A, B, buffer)
     end
 end
-RkMatrix(A,B) = RkMatrix(promote(A,B)...)
+RkMatrix(A, B) = RkMatrix(promote(A, B)...)
 
-function Base.setproperty!(R::RkMatrix,s::Symbol,mat::Matrix)
-    setfield!(R,s,mat)
+function Base.setproperty!(R::RkMatrix, s::Symbol, mat::Matrix)
+    setfield!(R, s, mat)
     # resize buffer
-    r = size(mat,2)
-    resize!(R.buffer,r)
+    r = size(mat, 2)
+    resize!(R.buffer, r)
     return R
 end
 
-function Base.getproperty(R::RkMatrix,s::Symbol)
-    if  s == :Bt
+function Base.getproperty(R::RkMatrix, s::Symbol)
+    if s == :Bt
         return adjoint(R.B)
-    elseif  s == :At
+    elseif s == :At
         return adjoint(R.A)
     else
-        return getfield(R,s)
+        return getfield(R, s)
     end
 end
 
-const RkMatrixBlockView{T} = SubArray{T, 2, RkMatrix{T}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}
+const RkMatrixBlockView{T} = SubArray{T,2,RkMatrix{T},
+                                      Tuple{UnitRange{Int64},UnitRange{Int64}},false}
 
-function Base.getproperty(Rv::RkMatrixBlockView,s::Symbol)
-    R   = getfield(Rv,:parent)
-    I,J = getfield(Rv,:indices)
-    if  s == :A
-        return view(R.A,I,:)
-    elseif  s == :B
-        return view(R.B,J,:)
-    elseif  s == :Bt
+function Base.getproperty(Rv::RkMatrixBlockView, s::Symbol)
+    R = getfield(Rv, :parent)
+    I, J = getfield(Rv, :indices)
+    if s == :A
+        return view(R.A, I, :)
+    elseif s == :B
+        return view(R.B, J, :)
+    elseif s == :Bt
         return adjoint(Rv.B)
-    elseif  s == :At
+    elseif s == :At
         return adjoint(Rv.A)
     else
-        return getfield(Rv,s)
+        return getfield(Rv, s)
     end
 end
 
-function Base.getindex(rmat::RkMatrix,i::Int,j::Int)
+function Base.getindex(rmat::RkMatrix, i::Int, j::Int)
     msg = """
     method `getindex(::AbstractHMatrix,args...)` has been disabled to avoid
     performance pitfalls. Unless you made an explicit call to `getindex`, this
@@ -72,7 +73,7 @@ function Base.getindex(rmat::RkMatrix,i::Int,j::Int)
         r = rank(rmat)
         acc = zero(eltype(rmat))
         for k in 1:r
-            acc += rmat.A[i,k] * conj(rmat.B[j,k])
+            acc += rmat.A[i, k] * conj(rmat.B[j, k])
         end
     else
         error(msg)
@@ -81,20 +82,23 @@ function Base.getindex(rmat::RkMatrix,i::Int,j::Int)
 end
 
 # some "fast" ways of computing a column of R and row of ajoint(R)
-Base.getindex(R::Union{RkMatrix,RkMatrixBlockView}, ::Colon, j::Int)                            = getcol(R,j)
-Base.getindex(Ra::Adjoint{<:Any,<:Union{RkMatrix,RkMatrixBlockView}}, ::Colon, j::Int)          = getcol(Ra,j)
+Base.getindex(R::Union{RkMatrix,RkMatrixBlockView}, ::Colon, j::Int) = getcol(R, j)
+function Base.getindex(Ra::Adjoint{<:Any,<:Union{RkMatrix,RkMatrixBlockView}}, ::Colon,
+                       j::Int)
+    return getcol(Ra, j)
+end
 
 """
     getcol(M::AbstractMatrix,j)
 
 Return a vector containing the `j`-th column of `M`.
 """
-function getcol(A::AbstractMatrix,j::Int)
-    m = size(A,1)
+function getcol(A::AbstractMatrix, j::Int)
+    m = size(A, 1)
     T = eltype(A)
     # col = Vector{T}(undef,m)
-    col = zeros(T,m)
-    getcol!(col,A,j)
+    col = zeros(T, m)
+    return getcol!(col, A, j)
 end
 
 """
@@ -103,29 +107,34 @@ end
 Fill the entries of `col` with column `j` of `M`. If `append=Val(true)`, the
 result will be *added* to `col`; otherwise it will just be written to `col`.
 """
-function getcol!(col,R::Union{RkMatrix,RkMatrixBlockView},j::Int,append::Val{T}=Val(false)) where T
+function getcol!(col, R::Union{RkMatrix,RkMatrixBlockView}, j::Int,
+                 append::Val{T}=Val(false)) where {T}
     if T
-        mul!(col,R.A,conj(view(R.B,j,:)),true,true)
+        mul!(col, R.A, conj(view(R.B, j, :)), true, true)
     else
-        mul!(col,R.A,conj(view(R.B,j,:)))
+        mul!(col, R.A, conj(view(R.B, j, :)))
     end
 end
 
-function getcol!(col,Ra::Adjoint{<:Any,<:Union{RkMatrix,RkMatrixBlockView}},j::Int,append::Val{T}=Val(false)) where {T}
+function getcol!(col,
+                 Ra::Adjoint{<:Any,<:Union{RkMatrix,RkMatrixBlockView}},
+                 j::Int,
+                 append::Val{T}=Val(false)) where {T}
     R = parent(Ra)
     if T
-        mul!(col,R.B,conj(view(R.A,j,:)),true,true)
+        mul!(col, R.B, conj(view(R.A, j, :)), true, true)
     else
-        mul!(col,R.B,conj(view(R.A,j,:)))
+        mul!(col, R.B, conj(view(R.A, j, :)))
     end
 end
 
-function getcol!(col,Ra::Adjoint{<:Any,<:RkMatrixBlockView},j::Int,append::Val{T}=Val(false)) where {T}
+function getcol!(col, Ra::Adjoint{<:Any,<:RkMatrixBlockView}, j::Int,
+                 append::Val{T}=Val(false)) where {T}
     R = parent(Ra)
     if T
-        mul!(col,R.B,conj(view(R.A,j,:)),1,1)
+        mul!(col, R.B, conj(view(R.A, j, :)), 1, 1)
     else
-        mul!(col,R.B,conj(view(R.A,j,:)))
+        mul!(col, R.B, conj(view(R.A, j, :)))
     end
 end
 
@@ -136,28 +145,30 @@ Construct an `RkMatrix` from a vector of vectors. Assumes that `length(A) ==
 length(B)`, which determines the rank, and that all vectors in `A` (resp. `B`) have the same length `m`
 (resp. `n`).
 """
-function RkMatrix(_A::Vector{V},_B::Vector{V}) where {V<:AbstractVector}
-    T   = eltype(V)
+function RkMatrix(_A::Vector{V}, _B::Vector{V}) where {V<:AbstractVector}
+    T = eltype(V)
     @assert length(_A) == length(_B)
-    k   = length(_A)
-    m   = length(first(_A))
-    n   = length(first(_B))
-    A   = Matrix{T}(undef,m,k)
-    B  = Matrix{T}(undef,n,k)
+    k = length(_A)
+    m = length(first(_A))
+    n = length(first(_B))
+    A = Matrix{T}(undef, m, k)
+    B = Matrix{T}(undef, n, k)
     for i in 1:k
-        copyto!(view(A,:,i),_A[i])
-        copyto!(view(B,:,i),_B[i])
+        copyto!(view(A, :, i), _A[i])
+        copyto!(view(B, :, i), _B[i])
     end
-    return RkMatrix(A,B)
+    return RkMatrix(A, B)
 end
 
 Base.eltype(::RkMatrix{T}) where {T} = T
-Base.size(rmat::RkMatrix)                                        = (size(rmat.A,1), size(rmat.B,1))
-Base.length(rmat::RkMatrix)                                      = prod(size(rmat))
-Base.isapprox(rmat::RkMatrix,B::AbstractArray,args...;kwargs...) = isapprox(Matrix(rmat),B,args...;kwargs...)
+Base.size(rmat::RkMatrix) = (size(rmat.A, 1), size(rmat.B, 1))
+Base.length(rmat::RkMatrix) = prod(size(rmat))
+function Base.isapprox(rmat::RkMatrix, B::AbstractArray, args...; kwargs...)
+    return isapprox(Matrix(rmat), B, args...; kwargs...)
+end
 
-rank(M::RkMatrix) = size(M.A,2)
-rank(M::RkMatrixBlockView) = size(M.parent.A,2)
+rank(M::RkMatrix) = size(M.A, 2)
+rank(M::RkMatrixBlockView) = size(M.parent.A, 2)
 
 """
     hcat(M1::RkMatrix,M2::RkMatrix)
@@ -165,17 +176,18 @@ rank(M::RkMatrixBlockView) = size(M.parent.A,2)
 Concatenated `M1` and `M2` horizontally to produce a new `RkMatrix` of rank
 `rank(M1)+rank(M2)`.
 """
-function Base.hcat(M1::RkMatrix{T},M2::RkMatrix{T}) where {T}
-    m,n  = size(M1)
-    s,t  = size(M2)
-    (m == s) || throw(ArgumentError("number of rows of each array must match: got  ($m,$s)"))
-    r1   = size(M1.A,2)
-    r2   = size(M2.A,2)
-    A    = hcat(M1.A,M2.A)
-    B1   = vcat(M1.B,zeros(T,t,r1))
-    B2   = vcat(zeros(T,n,r2),M2.B)
-    B    = hcat(B1,B2)
-    return RkMatrix(A,B)
+function Base.hcat(M1::RkMatrix{T}, M2::RkMatrix{T}) where {T}
+    m, n = size(M1)
+    s, t = size(M2)
+    (m == s) ||
+        throw(ArgumentError("number of rows of each array must match: got  ($m,$s)"))
+    r1 = size(M1.A, 2)
+    r2 = size(M2.A, 2)
+    A = hcat(M1.A, M2.A)
+    B1 = vcat(M1.B, zeros(T, t, r1))
+    B2 = vcat(zeros(T, n, r2), M2.B)
+    B = hcat(B1, B2)
+    return RkMatrix(A, B)
 end
 
 """
@@ -184,28 +196,29 @@ end
 Concatenated `M1` and `M2` vertically to produce a new `RkMatrix` of rank
 `rank(M1)+rank(M2)`
 """
-function Base.vcat(M1::RkMatrix{T},M2::RkMatrix{T}) where {T}
-    m,n  = size(M1)
-    s,t  = size(M2)
-    n == t || throw(ArgumentError("number of columns of each array must match (got  ($n,$t))"))
-    r1   = size(M1.A,2)
-    r2   = size(M2.A,2)
-    A1   = vcat(M1.A,zeros(T,s,r1))
-    A2   = vcat(zeros(T,m,r2),M2.A)
-    A    = hcat(A1,A2)
-    B    = hcat(M1.B,M2.B)
-    return RkMatrix(A,B)
+function Base.vcat(M1::RkMatrix{T}, M2::RkMatrix{T}) where {T}
+    m, n = size(M1)
+    s, t = size(M2)
+    n == t ||
+        throw(ArgumentError("number of columns of each array must match (got  ($n,$t))"))
+    r1 = size(M1.A, 2)
+    r2 = size(M2.A, 2)
+    A1 = vcat(M1.A, zeros(T, s, r1))
+    A2 = vcat(zeros(T, m, r2), M2.A)
+    A = hcat(A1, A2)
+    B = hcat(M1.B, M2.B)
+    return RkMatrix(A, B)
 end
 
-Base.copy(R::RkMatrix) = RkMatrix(copy(R.A),copy(R.B))
+Base.copy(R::RkMatrix) = RkMatrix(copy(R.A), copy(R.B))
 
 function Base.Matrix(R::RkMatrix{<:Number})
-    Matrix(R.A*R.Bt)
+    return Matrix(R.A * R.Bt)
 end
 function Base.Matrix(R::RkMatrix{<:SMatrix})
     # collect must be used when we have a matrix of `SMatrix` because of this issue:
     # https://github.com/JuliaArrays/StaticArrays.jl/issues/966#issuecomment-943679214
-    R.A*collect(R.Bt)
+    return R.A * collect(R.Bt)
 end
 
 """
@@ -214,9 +227,9 @@ end
 Construct an [`RkMatrix`](@ref) from an `SVD` factorization.
 """
 function RkMatrix(F::SVD)
-    A  = F.U*Diagonal(F.S)
-    B  = copy(F.V)
-    return RkMatrix(A,B)
+    A = F.U * Diagonal(F.S)
+    B = copy(F.V)
+    return RkMatrix(A, B)
 end
 
 """
@@ -227,7 +240,7 @@ Construct an [`RkMatrix`](@ref) from a `Matrix` by passing through the full
 """
 function RkMatrix(M::Matrix)
     F = svd(M)
-    RkMatrix(F)
+    return RkMatrix(F)
 end
 
 """
@@ -236,7 +249,7 @@ end
 The number of entries stored in the representation. Note that this is *not*
 `length(R)`.
 """
-num_stored_elements(R::RkMatrix)        = size(R.A,2)*(sum(size(R)))
+num_stored_elements(R::RkMatrix) = size(R.A, 2) * (sum(size(R)))
 
 """
     compression_ratio(R::RkMatrix)
@@ -252,15 +265,16 @@ compression_ratio(R::RkMatrix) = prod(size(R)) / num_stored_elements(R)
 # problem in LinearAlgebra for the generic mulplication mul!(C,A,B,a,b) when
 # C and B are a vectors of static matrices, and A is a matrix of static
 # matrices. Should eventually be removed.
-function mul!(C::AbstractVector,Rk::RkMatrix{T},F::AbstractVector,a::Number,b::Number) where {T<:SMatrix}
-    m,n = size(Rk)
-    r   = rank(Rk)
-    tmp = Rk.Bt*F
-    rmul!(C,b)
+function mul!(C::AbstractVector, Rk::RkMatrix{T}, F::AbstractVector, a::Number,
+              b::Number) where {T<:SMatrix}
+    m, n = size(Rk)
+    r = rank(Rk)
+    tmp = Rk.Bt * F
+    rmul!(C, b)
     for k in 1:r
         tmp[k] *= a
         for i in 1:m
-            C[i] += Rk.A[i,k]*tmp[k]
+            C[i] += Rk.A[i, k] * tmp[k]
         end
     end
     return C

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1,5 +1,5 @@
 const HUnitLowerTriangular = UnitLowerTriangular{<:Any,<:HMatrix}
-const HUpperTriangular     = UpperTriangular{<:Any,<:HMatrix}
+const HUpperTriangular = UpperTriangular{<:Any,<:HMatrix}
 
 function ldiv!(L::HUnitLowerTriangular, B::StridedMatrix)
     H = parent(L)
@@ -9,19 +9,19 @@ function ldiv!(L::HUnitLowerTriangular, B::StridedMatrix)
     else
         @assert !hasdata(H) "only leaves are allowed to have data when using `ldiv`!"
         shift = pivot(H) .- 1
-        chdH  = children(H)
-        m, n   = size(chdH)
+        chdH = children(H)
+        m, n = size(chdH)
         @assert m === n
-        for i = 1:m
-            irows  = colrange(chdH[i,i]) .- shift[2]
-            bi     = view(B, irows, :)
-            for j = 1:(i - 1)# j<i
-                jrows  = colrange(chdH[i,j]) .- shift[2]
-                bj     = view(B, jrows, :)
-                _mul131!(bi, chdH[i,j], bj, -1)
+        for i in 1:m
+            irows = colrange(chdH[i, i]) .- shift[2]
+            bi = view(B, irows, :)
+            for j in 1:(i - 1)# j<i
+                jrows = colrange(chdH[i, j]) .- shift[2]
+                bj = view(B, jrows, :)
+                _mul131!(bi, chdH[i, j], bj, -1)
             end
             # recursion stage
-            ldiv!(UnitLowerTriangular(chdH[i,i]), bi)
+            ldiv!(UnitLowerTriangular(chdH[i, i]), bi)
         end
     end
     return B
@@ -42,16 +42,16 @@ function ldiv!(L::HUnitLowerTriangular, X::HMatrix, compressor)
     else
         chdH = children(H)
         chdX = children(X)
-        m, n  = size(chdH)
+        m, n = size(chdH)
         @assert m == n
         for k in 1:size(chdX, 2)
-            for i = 1:m
-                for j = 1:(i - 1)# j<i
+            for i in 1:m
+                for j in 1:(i - 1)# j<i
                     @timeit_debug "hmul!" begin
-                        hmul!(chdX[i,k], chdH[i,j], chdX[j,k], -1, 1, compressor)
+                        hmul!(chdX[i, k], chdH[i, j], chdX[j, k], -1, 1, compressor)
                     end
                 end
-                ldiv!(UnitLowerTriangular(chdH[i,i]), chdX[i,k], compressor)
+                ldiv!(UnitLowerTriangular(chdH[i, i]), chdX[i, k], compressor)
             end
         end
     end
@@ -66,19 +66,19 @@ function ldiv!(U::HUpperTriangular, B::AbstractMatrix)
     else
         @assert !hasdata(H) "only leaves are allowed to have data when using `ldiv`!"
         shift = pivot(H) .- 1
-        chdH  = children(H)
-        m, n   = size(chdH)
+        chdH = children(H)
+        m, n = size(chdH)
         @assert m === n
-        for i = m:-1:1
-            irows  = colrange(chdH[i,i]) .- shift[2]
-            bi     = view(B, irows, :)
-            for j = i+1:n # j>i
-                jrows  = colrange(chdH[i,j]) .- shift[2]
-                bj     = view(B, jrows, :)
-                _mul131!(bi, chdH[i,j], bj, -1)
+        for i in m:-1:1
+            irows = colrange(chdH[i, i]) .- shift[2]
+            bi = view(B, irows, :)
+            for j in (i + 1):n # j>i
+                jrows = colrange(chdH[i, j]) .- shift[2]
+                bj = view(B, jrows, :)
+                _mul131!(bi, chdH[i, j], bj, -1)
             end
             # recursion stage
-            ldiv!(UpperTriangular(chdH[i,i]), bi)
+            ldiv!(UpperTriangular(chdH[i, i]), bi)
         end
     end
     return B
@@ -92,20 +92,20 @@ function rdiv!(B::StridedMatrix, U::HUpperTriangular)
         rdiv!(B, UpperTriangular(d)) # b <-- b/L
     else
         @assert !hasdata(H) "only leaves are allowed to have data when using `rdiv`!"
-        shift = pivot(H) .- 1 |> reverse
-        chdH  = children(H)
-        m, n   = size(chdH)
+        shift = reverse(pivot(H) .- 1)
+        chdH = children(H)
+        m, n = size(chdH)
         @assert m === n
-        for i = 1:m
-            icols  = rowrange(chdH[i,i]) .- shift[1]
-            bi     = view(B, :, icols)
-            for j = 1:(i - 1)
-                jcols  = rowrange(chdH[j,i]) .- shift[1]
-                bj     = view(B, :, jcols)
-                _mul113!(bi, bj, chdH[j,i], -1)
+        for i in 1:m
+            icols = rowrange(chdH[i, i]) .- shift[1]
+            bi = view(B, :, icols)
+            for j in 1:(i - 1)
+                jcols = rowrange(chdH[j, i]) .- shift[1]
+                bj = view(B, :, jcols)
+                _mul113!(bi, bj, chdH[j, i], -1)
             end
             # recursion stage
-            rdiv!(bi, UpperTriangular(chdH[i,i]))
+            rdiv!(bi, UpperTriangular(chdH[i, i]))
         end
     end
     return B
@@ -131,13 +131,13 @@ function rdiv!(X::AbstractHMatrix, U::HUpperTriangular, compressor)
         chdH = children(H)
         m, n = size(chdH)
         for k in 1:size(chdX, 1)
-            for i = 1:m
-                for j = 1:(i - 1)
+            for i in 1:m
+                for j in 1:(i - 1)
                     @timeit_debug "hmul!" begin
-                        hmul!(chdX[k,i], chdX[k,j], chdH[j,i], -1, 1, compressor)
+                        hmul!(chdX[k, i], chdX[k, j], chdH[j, i], -1, 1, compressor)
                     end
                 end
-                rdiv!(chdX[k,i], UpperTriangular(chdH[i,i]), compressor)
+                rdiv!(chdX[k, i], UpperTriangular(chdH[i, i]), compressor)
             end
         end
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -137,3 +137,57 @@ disable_getindex() = (ALLOW_GETINDEX[] = false)
 The opposite of [`disable_getindex`](@ref).
 """
 enable_getindex()  = (ALLOW_GETINDEX[] = true)
+
+
+"""
+    @usethreads bool expr
+
+Append `Threads.@threads` if `bool==true` (see
+https://discourse.julialang.org/t/putting-threads-threads-or-any-macro-in-an-if-statement/41406/8)
+"""
+macro usethreads(multithreaded, expr::Expr)
+    ex = quote
+        if $multithreaded
+            Threads.@threads $expr
+        else
+            $expr
+        end
+    end
+    esc(ex)
+end
+
+"""
+    @usespawn bool expr
+
+Append `Threads.@spawn` if `bool==true`.
+"""
+macro usespawn(multithreaded, expr::Expr)
+    ex = quote
+        if $multithreaded
+            Threads.@spawn $expr
+        else
+            $expr
+        end
+    end
+    esc(ex)
+end
+
+"""
+    struct CanonicalUnitVector
+
+Cartesian basis vector `eᵢ` with `eᵢ[j] = 1` if `i==j` and `0` otherwise.
+"""
+struct CanonicalBasisElement <: AbstractVector{Bool}
+    index::Int
+    length::Int
+end
+
+Base.size(x::CanonicalBasisElement) = (x.length,)
+Base.getindex(x::CanonicalBasisElement,i::Int) = (i==x.index)
+
+nonzero_index(e::CanonicalBasisElement) = e.index
+
+# function Base.:*(A::AbstractMatrix{T},x::CanonicalBasisElement) where {T}
+#     y = Vector{T}(undef,size(A,1))
+#     mul!(y,A,x)
+# end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,18 +30,18 @@ struct PermutedMatrix{K,T} <: AbstractMatrix{T}
     data::K # original matrix
     rowperm::Vector{Int}
     colperm::Vector{Int}
-    function PermutedMatrix(orig,rowperm,colperm)
+    function PermutedMatrix(orig, rowperm, colperm)
         K = typeof(orig)
         T = eltype(orig)
-        new{K,T}(orig,rowperm,colperm)
+        return new{K,T}(orig, rowperm, colperm)
     end
 end
 Base.size(M::PermutedMatrix) = size(M.data)
 
-function Base.getindex(M::PermutedMatrix,i,j)
+function Base.getindex(M::PermutedMatrix, i, j)
     ip = M.rowperm[i]
     jp = M.colperm[j]
-    M.data[ip,jp]
+    return M.data[ip, jp]
 end
 
 """
@@ -53,20 +53,20 @@ output `d` ranges from `0` to `n^2-1`.
 
 See [https://en.wikipedia.org/wiki/Hilbert_curve](https://en.wikipedia.org/wiki/Hilbert_curve).
 """
-function hilbert_cartesian_to_linear(n::Integer,x,y)
+function hilbert_cartesian_to_linear(n::Integer, x, y)
     @assert ispow2(n)
-    @assert 0 ≤ x ≤ n-1
-    @assert 0 ≤ y ≤ n-1
+    @assert 0 ≤ x ≤ n - 1
+    @assert 0 ≤ y ≤ n - 1
     d = 0
     s = n >> 1
-    while s>0
+    while s > 0
         rx = (x & s) > 0
         ry = (y & s) > 0
-        d += s^2*((3*rx)⊻ry)
-        x,y = _rot(n,x,y,rx,ry)
+        d += s^2 * ((3 * rx) ⊻ ry)
+        x, y = _rot(n, x, y, rx, ry)
         s = s >> 1
     end
-    @assert 0 ≤ d ≤ n^2-1
+    @assert 0 ≤ d ≤ n^2 - 1
     return d
 end
 
@@ -78,47 +78,47 @@ n-1` and `0 ≤ y ≤ n-1` on the Hilbert curve of order `n`.
 
 See [https://en.wikipedia.org/wiki/Hilbert_curve](https://en.wikipedia.org/wiki/Hilbert_curve).
 """
-function hilbert_linear_to_cartesian(n::Integer,d)
+function hilbert_linear_to_cartesian(n::Integer, d)
     @assert ispow2(n)
-    @assert 0 ≤ d ≤ n^2-1
-    x,y = 0,0
+    @assert 0 ≤ d ≤ n^2 - 1
+    x, y = 0, 0
     s = 1
-    while s<n
+    while s < n
         rx = 1 & (d >> 1)
         ry = 1 & (d ⊻ rx)
-        x,y = _rot(s,x,y,rx,ry)
-        x +=  s*rx
-        y +=  s*ry
+        x, y = _rot(s, x, y, rx, ry)
+        x += s * rx
+        y += s * ry
         d = d >> 2
         s = s << 1
     end
-    @assert 0 ≤ x ≤ n-1
-    @assert 0 ≤ y ≤ n-1
-    return x,y
+    @assert 0 ≤ x ≤ n - 1
+    @assert 0 ≤ y ≤ n - 1
+    return x, y
 end
 
 # auxiliary function using in hilbert curve. Rotates the points x,y
-function _rot(n,x,y,rx,ry)
+function _rot(n, x, y, rx, ry)
     if ry == 0
         if rx == 1
-            x = n-1 - x
-            y = n-1 - y
+            x = n - 1 - x
+            y = n - 1 - y
         end
-        x,y = y,x
+        x, y = y, x
     end
-    return x,y
+    return x, y
 end
 
 function hilbert_points(n::Integer)
     @assert ispow2(n)
     xx = Int[]
     yy = Int[]
-    for d in 0:n^2-1
-        x,y = hilbert_linear_to_cartesian(n,d)
-        push!(xx,x)
-        push!(yy,y)
+    for d in 0:(n^2 - 1)
+        x, y = hilbert_linear_to_cartesian(n, d)
+        push!(xx, x)
+        push!(yy, y)
     end
-    xx,yy
+    return xx, yy
 end
 
 """
@@ -136,8 +136,7 @@ disable_getindex() = (ALLOW_GETINDEX[] = false)
 
 The opposite of [`disable_getindex`](@ref).
 """
-enable_getindex()  = (ALLOW_GETINDEX[] = true)
-
+enable_getindex() = (ALLOW_GETINDEX[] = true)
 
 """
     @usethreads bool expr
@@ -153,7 +152,7 @@ macro usethreads(multithreaded, expr::Expr)
             $expr
         end
     end
-    esc(ex)
+    return esc(ex)
 end
 
 """
@@ -169,7 +168,7 @@ macro usespawn(multithreaded, expr::Expr)
             $expr
         end
     end
-    esc(ex)
+    return esc(ex)
 end
 
 """
@@ -183,7 +182,7 @@ struct CanonicalBasisElement <: AbstractVector{Bool}
 end
 
 Base.size(x::CanonicalBasisElement) = (x.length,)
-Base.getindex(x::CanonicalBasisElement,i::Int) = (i==x.index)
+Base.getindex(x::CanonicalBasisElement, i::Int) = (i == x.index)
 
 nonzero_index(e::CanonicalBasisElement) = e.index
 

--- a/test/addition_test.jl
+++ b/test/addition_test.jl
@@ -5,36 +5,36 @@ using Random
 using StaticArrays
 using HMatrices: RkMatrix
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
-N,r     = 500,3
-atol    = 1e-6
-X  = Y     = rand(SVector{3,Float64},N)
-splitter = CardinalitySplitter(nmax=50)
-Xclt = Yclt  = ClusterTree(X,splitter)
-adm       = StrongAdmissibilityStd(eta=3)
-rtol      = 1e-5
-comp      = PartialACA(rtol=rtol)
-K         = helmholtz_matrix(X,Y,1.3)
-H         = assemble_hmat(K,Xclt,Yclt;adm,comp,threads=false,distributed=false)
-T         = eltype(H)
-_H   = Matrix(H;global_index=false)
-R    = RkMatrix(rand(T,N,r),rand(T,N,r))
-_R   = Matrix(R)
-M    = rand(T,N,N)
-_M   = Matrix(M)
-a    = rand()
+N, r = 500, 3
+atol = 1e-6
+X = Y = rand(SVector{3,Float64}, N)
+splitter = CardinalitySplitter(; nmax=50)
+Xclt = Yclt = ClusterTree(X, splitter)
+adm = StrongAdmissibilityStd(; eta=3)
+rtol = 1e-5
+comp = PartialACA(; rtol=rtol)
+K = helmholtz_matrix(X, Y, 1.3)
+H = assemble_hmat(K, Xclt, Yclt; adm, comp, threads=false, distributed=false)
+T = eltype(H)
+_H = Matrix(H; global_index=false)
+R = RkMatrix(rand(T, N, r), rand(T, N, r))
+_R = Matrix(R)
+M = rand(T, N, N)
+_M = Matrix(M)
+a = rand()
 
 @testset "axpy!" begin
-    @test axpy!(a,M,deepcopy(R)) ≈ a*_M + _R
-    tmp = axpy!(a,M,deepcopy(H))
-    @test Matrix(tmp;global_index=false) ≈ a*_M + _H
-    @test axpy!(a,R,deepcopy(M)) ≈ a*_R + _M
-    @test axpy!(a,R,deepcopy(R)) ≈ a*_R + _R
-    tmp = axpy!(a,R,deepcopy(H))
-    Matrix(tmp;global_index=false) ≈ a*_R + _H
-    @test axpy!(a,H,deepcopy(M)) ≈ a*_H + _M
-    @test axpy!(a,H,deepcopy(R)) ≈ a*_H + _R
-    tmp = axpy!(a,H,deepcopy(H))
-    @test Matrix(tmp;global_index=false) ≈ a*_H + _H
+    @test axpy!(a, M, deepcopy(R)) ≈ a * _M + _R
+    tmp = axpy!(a, M, deepcopy(H))
+    @test Matrix(tmp; global_index=false) ≈ a * _M + _H
+    @test axpy!(a, R, deepcopy(M)) ≈ a * _R + _M
+    @test axpy!(a, R, deepcopy(R)) ≈ a * _R + _R
+    tmp = axpy!(a, R, deepcopy(H))
+    Matrix(tmp; global_index=false) ≈ a * _R + _H
+    @test axpy!(a, H, deepcopy(M)) ≈ a * _H + _M
+    @test axpy!(a, H, deepcopy(R)) ≈ a * _H + _R
+    tmp = axpy!(a, H, deepcopy(H))
+    @test Matrix(tmp; global_index=false) ≈ a * _H + _H
 end

--- a/test/compressor_test.jl
+++ b/test/compressor_test.jl
@@ -4,142 +4,141 @@ using StaticArrays
 using LinearAlgebra
 using HMatrices: ACA, PartialACA, TSVD, RkMatrix
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 using Random
 Random.seed!(1)
 
 @testset "Scalar" begin
     T = ComplexF64
-    m,n = 100,100
-    X = rand(SVector{3,Float64},m)
-    Y = map(i->SVector(10,0,0) + rand(SVector{3,Float64}),1:n)
-    K = helmholtz_matrix(X,Y,1.0)
+    m, n = 100, 100
+    X = rand(SVector{3,Float64}, m)
+    Y = map(i -> SVector(10, 0, 0) + rand(SVector{3,Float64}), 1:n)
+    K = helmholtz_matrix(X, Y, 1.0)
     M = Matrix(K)
-    irange,jrange = 1:m,1:n
+    irange, jrange = 1:m, 1:n
     @testset "aca_full" begin
         atol = 1e-5
-        aca = ACA(atol=atol)
-        R = aca(K,irange,jrange)
+        aca = ACA(; atol=atol)
+        R = aca(K, irange, jrange)
         @test norm(Matrix(R) - M) < atol
         rtol = 1e-5
-        aca = ACA(rtol=rtol)
-        R   = aca(M,irange,jrange)
+        aca = ACA(; rtol=rtol)
+        R = aca(M, irange, jrange)
         norm(Matrix(R) - M)
-        @test norm(Matrix(R) - M) < rtol*norm(M)
+        @test norm(Matrix(R) - M) < rtol * norm(M)
         r = 10
-        aca = ACA(rank=r)
-        R = aca(M,irange,jrange)
+        aca = ACA(; rank=r)
+        R = aca(M, irange, jrange)
         @test rank(R) == r
     end
     @testset "aca_partial" begin
         atol = 1e-5
-        aca = PartialACA(atol=atol)
-        R = aca(M,irange,jrange)
+        aca = PartialACA(; atol=atol)
+        R = aca(M, irange, jrange)
         @test norm(Matrix(R) - M) < atol
         rtol = 1e-5
-        aca = PartialACA(rtol=rtol)
-        R = aca(M,irange,jrange)
-        @test norm(Matrix(R) - M) < rtol*norm(M)
+        aca = PartialACA(; rtol=rtol)
+        R = aca(M, irange, jrange)
+        @test norm(Matrix(R) - M) < rtol * norm(M)
         r = 10
-        aca = PartialACA(rank=r)
-        R = aca(M,irange,jrange)
+        aca = PartialACA(; rank=r)
+        R = aca(M, irange, jrange)
         @test rank(R) == r
 
         # test fast update of frobenius norm
-        m,n = 10000,1000
+        m, n = 10000, 1000
         r = 10
         T = ComplexF64
-        A = [rand(T,m) for _ in 1:r]
-        B = [rand(T,n) for _ in 1:r]
-        R = RkMatrix(A,B)
-        old_norm = norm(Matrix(R),2)
-        push!(A,rand(T,m))
-        push!(B,rand(T,n))
-        Rnew = RkMatrix(A,B)
-        new_norm = norm(Matrix(Rnew),2)
-        @test new_norm ≈ HMatrices._update_frob_norm(old_norm,A,B)
+        A = [rand(T, m) for _ in 1:r]
+        B = [rand(T, n) for _ in 1:r]
+        R = RkMatrix(A, B)
+        old_norm = norm(Matrix(R), 2)
+        push!(A, rand(T, m))
+        push!(B, rand(T, n))
+        Rnew = RkMatrix(A, B)
+        new_norm = norm(Matrix(Rnew), 2)
+        @test new_norm ≈ HMatrices._update_frob_norm(old_norm, A, B)
 
         # test simple case where things are not compressible
-        A  = rand(2,2)
-        comp = PartialACA(rtol=1e-5)
-        @test comp(A,1:2,1:2) ≈ A
+        A = rand(2, 2)
+        comp = PartialACA(; rtol=1e-5)
+        @test comp(A, 1:2, 1:2) ≈ A
     end
     @testset "truncated svd" begin
         atol = 1e-5
-        tsvd = TSVD(atol=atol)
-        R    = tsvd(M,irange,jrange)
+        tsvd = TSVD(; atol=atol)
+        R = tsvd(M, irange, jrange)
         # the inequality below is guaranteed to be true  for  the spectral norm
         # i.e. (the `opnorm` with `p=2`).
         @test opnorm(Matrix(R) - M) < atol
         rtol = 1e-5
-        tsvd = TSVD(rtol=rtol)
-        R    = tsvd(M,irange,jrange)
-        @test opnorm(Matrix(R) - M) < rtol*opnorm(M)
+        tsvd = TSVD(; rtol=rtol)
+        R = tsvd(M, irange, jrange)
+        @test opnorm(Matrix(R) - M) < rtol * opnorm(M)
         r = 10
-        tsvd = TSVD(rank=r)
-        R  = tsvd(M,irange,jrange)
+        tsvd = TSVD(; rank=r)
+        R = tsvd(M, irange, jrange)
         @test rank(R) == r
     end
 end
 
-
 @testset "Tensorial" begin
     T = SMatrix{3,3,ComplexF64,9}
     # T = SMatrix{3,3,Float64,9}
-    m,n = 100,100
-    X = rand(SVector{3,Float64},m)
-    Y = map(i->SVector(10,0,0) + rand(SVector{3,Float64}),1:n)
-    K = elastosdynamic_matrix(X,Y,1.0,2.0,1.0,1.0)
+    m, n = 100, 100
+    X = rand(SVector{3,Float64}, m)
+    Y = map(i -> SVector(10, 0, 0) + rand(SVector{3,Float64}), 1:n)
+    K = elastosdynamic_matrix(X, Y, 1.0, 2.0, 1.0, 1.0)
     # K = ElastostaticMatrix(X,Y,1.0,2.0)
     M = Matrix(K)
-    irange,jrange = 1:m,1:n
+    irange, jrange = 1:m, 1:n
     @testset "aca_full" begin
         atol = 1e-5
-        aca = ACA(atol=atol)
-        R = aca(K,irange,jrange);
+        aca = ACA(; atol=atol)
+        R = aca(K, irange, jrange)
         @test norm(Matrix(R) - M) < atol
         rtol = 1e-5
-        aca = ACA(rtol=rtol)
-        R   = aca(M,irange,jrange)
+        aca = ACA(; rtol=rtol)
+        R = aca(M, irange, jrange)
         norm(Matrix(R) - M)
-        @test norm(Matrix(R) - M) < rtol*norm(M)
+        @test norm(Matrix(R) - M) < rtol * norm(M)
         r = 10
-        aca = ACA(rank=r)
-        R = aca(M,irange,jrange);
+        aca = ACA(; rank=r)
+        R = aca(M, irange, jrange)
         @test rank(R) == r
     end
     @testset "aca_partial" begin
         atol = 1e-5
-        aca = PartialACA(atol=atol)
-        R = aca(M,irange,jrange)
+        aca = PartialACA(; atol=atol)
+        R = aca(M, irange, jrange)
         @test norm(Matrix(R) - M) < atol
         rtol = 1e-5
-        aca = PartialACA(rtol=rtol)
-        R = aca(M,irange,jrange)
-        @test norm(Matrix(R) - M) < rtol*norm(M)
+        aca = PartialACA(; rtol=rtol)
+        R = aca(M, irange, jrange)
+        @test norm(Matrix(R) - M) < rtol * norm(M)
         r = 10
-        aca = PartialACA(rank=r)
-        R = aca(M,irange,jrange);
+        aca = PartialACA(; rank=r)
+        R = aca(M, irange, jrange)
         @test rank(R) == r
 
         # test fast update of frobenius norm
-        m,n = 10000,1000
+        m, n = 10000, 1000
         r = 10
         T = ComplexF64
-        A = [rand(T,m) for _ in 1:r]
-        B = [rand(T,n) for _ in 1:r]
-        R = RkMatrix(A,B)
-        old_norm = norm(Matrix(R),2)
-        push!(A,rand(T,m))
-        push!(B,rand(T,n))
-        Rnew = RkMatrix(A,B)
-        new_norm = norm(Matrix(Rnew),2)
-        @test new_norm ≈ HMatrices._update_frob_norm(old_norm,A,B)
+        A = [rand(T, m) for _ in 1:r]
+        B = [rand(T, n) for _ in 1:r]
+        R = RkMatrix(A, B)
+        old_norm = norm(Matrix(R), 2)
+        push!(A, rand(T, m))
+        push!(B, rand(T, n))
+        Rnew = RkMatrix(A, B)
+        new_norm = norm(Matrix(Rnew), 2)
+        @test new_norm ≈ HMatrices._update_frob_norm(old_norm, A, B)
 
         # test simple case where things are not compressible
-        A  = rand(2,2)
-        comp = PartialACA(rtol=1e-5)
-        @test comp(A,1:2,1:2) ≈ A
+        A = rand(2, 2)
+        comp = PartialACA(; rtol=1e-5)
+        @test comp(A, 1:2, 1:2) ≈ A
     end
 end

--- a/test/dhmatrix_test.jl
+++ b/test/dhmatrix_test.jl
@@ -4,21 +4,21 @@ addprocs(4; exeflags=`--project=$(Base.active_project())`)
 using Test
 using StaticArrays
 @everywhere using HMatrices
-@everywhere include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+@everywhere include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 @testset "Assemble" begin
-    m,n  = 10_000,10_000
-    X  = Y    = points_on_cylinder(1,m)
-    splitter  = CardinalitySplitter(nmax=100)
-    Xclt = Yclt = ClusterTree(X,splitter)
-    adm       = StrongAdmissibilityStd(eta=3)
-    atol      = 1e-6
-    comp      = PartialACA(;atol)
+    m, n = 10_000, 10_000
+    X = Y = points_on_cylinder(1, m)
+    splitter = CardinalitySplitter(; nmax=100)
+    Xclt = Yclt = ClusterTree(X, splitter)
+    adm = StrongAdmissibilityStd(; eta=3)
+    atol = 1e-6
+    comp = PartialACA(; atol)
     # Laplace
-    K         = laplace_matrix(X,Y)
-    H         = assemble_hmat(K,Xclt,Yclt;adm,comp,distributed=false,threads=true)
-    Hd        = assemble_hmat(K,Xclt,Yclt;adm,comp,distributed=true,threads=false)
+    K = laplace_matrix(X, Y)
+    H = assemble_hmat(K, Xclt, Yclt; adm, comp, distributed=false, threads=true)
+    Hd = assemble_hmat(K, Xclt, Yclt; adm, comp, distributed=true, threads=false)
     x = rand(n)
     y = rand(m)
-    @test H*x ≈ Hd*x
+    @test H * x ≈ Hd * x
 end

--- a/test/hmatrix_test.jl
+++ b/test/hmatrix_test.jl
@@ -3,38 +3,38 @@ using StaticArrays
 using HMatrices
 using LinearAlgebra
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 @testset "Assemble" begin
-    m,n  = 1_000,1_000
-    X  = Y   = rand(SVector{3,Float64},m)
-    splitter  = CardinalitySplitter(nmax=20)
-    Xclt = Yclt = ClusterTree(X,splitter)
-    adm       = StrongAdmissibilityStd(eta=3)
-    rtol      = 1e-5
-    comp      = PartialACA(rtol=rtol)
+    m, n = 1_000, 1_000
+    X = Y = rand(SVector{3,Float64}, m)
+    splitter = CardinalitySplitter(; nmax=20)
+    Xclt = Yclt = ClusterTree(X, splitter)
+    adm = StrongAdmissibilityStd(; eta=3)
+    rtol = 1e-5
+    comp = PartialACA(; rtol=rtol)
     # Laplace
-    for threads in (false,true)
-        K         = laplace_matrix(X,Y)
-        H         = assemble_hmat(K,Xclt,Yclt;adm,comp,threads)
-        @test norm(Matrix(K) - Matrix(H;global_index=true)) < rtol*norm(Matrix(K))
-        H         = assemble_hmat(K;threads,distributed=false)
-        @test norm(Matrix(K) - Matrix(H;global_index=true)) < rtol*norm(Matrix(K))
-        adjH      = adjoint(H)
-        H_full    = Matrix(H;global_index=false)
+    for threads in (false, true)
+        K = laplace_matrix(X, Y)
+        H = assemble_hmat(K, Xclt, Yclt; adm, comp, threads)
+        @test norm(Matrix(K) - Matrix(H; global_index=true)) < rtol * norm(Matrix(K))
+        H = assemble_hmat(K; threads, distributed=false)
+        @test norm(Matrix(K) - Matrix(H; global_index=true)) < rtol * norm(Matrix(K))
+        adjH = adjoint(H)
+        H_full = Matrix(H; global_index=false)
         adjH_full = adjoint(H_full)
         @testset "getindex" begin
             HMatrices.enable_getindex()
-            @test H_full[8,64] ≈ H[8,64]
+            @test H_full[8, 64] ≈ H[8, 64]
             HMatrices.disable_getindex()
-            @test_throws ErrorException H_full[8,64] ≈ H[8,64]
+            @test_throws ErrorException H_full[8, 64] ≈ H[8, 64]
             HMatrices.enable_getindex()
-            @test H_full[:,666] ≈ H[:,666]
-            @test adjH_full[:,666] ≈ adjH[:,666]
+            @test H_full[:, 666] ≈ H[:, 666]
+            @test adjH_full[:, 666] ≈ adjH[:, 666]
         end
         # Elastostatic
-        K         = elastostatic_matrix(X,Y,1.1,1.2)
-        H         = assemble_hmat(K,Xclt,Yclt;adm,comp,threads)
-        @test norm(Matrix(K) - Matrix(H;global_index=true)) < rtol*norm(Matrix(K))
+        K = elastostatic_matrix(X, Y, 1.1, 1.2)
+        H = assemble_hmat(K, Xclt, Yclt; adm, comp, threads)
+        @test norm(Matrix(K) - Matrix(H; global_index=true)) < rtol * norm(Matrix(K))
     end
 end

--- a/test/hmatrix_test.jl
+++ b/test/hmatrix_test.jl
@@ -14,7 +14,7 @@ include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
     rtol      = 1e-5
     comp      = PartialACA(rtol=rtol)
     # Laplace
-    for threads in (true,false)
+    for threads in (false,true)
         K         = laplace_matrix(X,Y)
         H         = assemble_hmat(K,Xclt,Yclt;adm,comp,threads)
         @test norm(Matrix(K) - Matrix(H;global_index=true)) < rtol*norm(Matrix(K))

--- a/test/lu_test.jl
+++ b/test/lu_test.jl
@@ -6,29 +6,29 @@ using StaticArrays
 
 using HMatrices: RkMatrix
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 Random.seed!(1)
 
 m = 5000
 T = Float64
-X    = points_on_sphere(m)
-Y    = X
+X = points_on_sphere(m)
+Y = X
 
-K = laplace_matrix(X,X)
+K = laplace_matrix(X, X)
 
-splitter  = CardinalitySplitter(nmax=50)
-Xclt      = ClusterTree(X,splitter)
-Yclt      = ClusterTree(Y,splitter)
+splitter = CardinalitySplitter(; nmax=50)
+Xclt = ClusterTree(X, splitter)
+Yclt = ClusterTree(Y, splitter)
 adm = StrongAdmissibilityStd(3)
-comp = PartialACA(;atol=1e-10);
-H = assemble_hmat(K,Xclt,Yclt;adm,comp,threads=false,distributed=false)
-H_full      = Matrix(H)
+comp = PartialACA(; atol=1e-10);
+H = assemble_hmat(K, Xclt, Yclt; adm, comp, threads=false, distributed=false)
+H_full = Matrix(H)
 
 ##
-hlu   = lu(H;atol=1e-5)
-y     = rand(m)
-M     = Matrix(K)
-exact = M\y
-approx = hlu\y
-@test norm(exact - approx,Inf) < 1e-6
+hlu = lu(H; atol=1e-5)
+y = rand(m)
+M = Matrix(K)
+exact = M \ y
+approx = hlu \ y
+@test norm(exact - approx, Inf) < 1e-6

--- a/test/multiplication_test.jl
+++ b/test/multiplication_test.jl
@@ -6,59 +6,58 @@ using StaticArrays
 
 using HMatrices: RkMatrix
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 Random.seed!(1)
 
 m = 2000
 n = 2000
 
-X    = rand(SVector{3,Float64},m)
-Y    = [rand(SVector{3,Float64}) for _  in 1:n]
-splitter  = CardinalitySplitter(nmax=40)
-Xclt      = ClusterTree(X,splitter)
-Yclt      = ClusterTree(Y,splitter)
-adm       = StrongAdmissibilityStd(eta=3)
-rtol      = 1e-5
-comp      = PartialACA(rtol=rtol)
-K         = laplace_matrix(X,Y)
-H         = assemble_hmat(K,Xclt,Yclt;adm,comp,threads=false,distributed=false)
+X = rand(SVector{3,Float64}, m)
+Y = [rand(SVector{3,Float64}) for _ in 1:n]
+splitter = CardinalitySplitter(; nmax=40)
+Xclt = ClusterTree(X, splitter)
+Yclt = ClusterTree(Y, splitter)
+adm = StrongAdmissibilityStd(; eta=3)
+rtol = 1e-5
+comp = PartialACA(; rtol=rtol)
+K = laplace_matrix(X, Y)
+H = assemble_hmat(K, Xclt, Yclt; adm, comp, threads=false, distributed=false)
 
-H_full = Matrix(H;global_index=false)
+H_full = Matrix(H; global_index=false)
 
 α = rand() - 0.5
 β = rand() - 0.5
 @testset "hmul!" begin
-    C  = deepcopy(H);
-    tmp = β*H_full + α*H_full*H_full
-    root = HMatrices.hmul!(C,H,H,α,β,PartialACA(;atol=1e-6))
-    @test Matrix(C;global_index=false) ≈ tmp
+    C = deepcopy(H)
+    tmp = β * H_full + α * H_full * H_full
+    root = HMatrices.hmul!(C, H, H, α, β, PartialACA(; atol=1e-6))
+    @test Matrix(C; global_index=false) ≈ tmp
 end
 
 @testset "gemv" begin
-
-    α = rand()-0.5
-    β = rand()-0.5
+    α = rand() - 0.5
+    β = rand() - 0.5
     T = eltype(H)
-    m,n = size(H)
-    x = rand(T,n)
-    y = rand(T,m)
+    m, n = size(H)
+    x = rand(T, n)
+    y = rand(T, m)
 
     @testset "serial" begin
-        exact  = β*y + α*H_full*x
-        approx = mul!(copy(y),H,x,α,β;threads=false,global_index=false)
+        exact = β * y + α * H_full * x
+        approx = mul!(copy(y), H, x, α, β; threads=false, global_index=false)
         @test exact ≈ approx
-        exact  = β*y + α*Matrix(H;global_index=true)*x
-        approx = mul!(copy(y),H,x,α,β;threads=false,global_index=true)
+        exact = β * y + α * Matrix(H; global_index=true) * x
+        approx = mul!(copy(y), H, x, α, β; threads=false, global_index=true)
         @test exact ≈ approx
     end
 
     @testset "threads" begin
-        exact  = β*y + α*H_full*x
-        approx = mul!(copy(y),H,x,α,β;threads=true,global_index=false)
+        exact = β * y + α * H_full * x
+        approx = mul!(copy(y), H, x, α, β; threads=true, global_index=false)
         @test exact ≈ approx
-        exact  = β*y + α*Matrix(H;global_index=true)*x
-        approx = mul!(copy(y),H,x,α,β;threads=false,global_index=true)
+        exact = β * y + α * Matrix(H; global_index=true) * x
+        approx = mul!(copy(y), H, x, α, β; threads=false, global_index=true)
         @test exact ≈ approx
     end
 end

--- a/test/multiplication_test.jl
+++ b/test/multiplication_test.jl
@@ -31,7 +31,7 @@ H_full = Matrix(H;global_index=false)
 @testset "hmul!" begin
     C  = deepcopy(H);
     tmp = β*H_full + α*H_full*H_full
-    HMatrices.hmul!(C,H,H,α,β,PartialACA(;atol=1e-6))
+    root = HMatrices.hmul!(C,H,H,α,β,PartialACA(;atol=1e-6))
     @test Matrix(C;global_index=false) ≈ tmp
 end
 

--- a/test/rkmatrix_test.jl
+++ b/test/rkmatrix_test.jl
@@ -9,20 +9,20 @@ using HMatrices: RkMatrix, compression_ratio
         m = 20
         n = 30
         r = 5
-        A = rand(ComplexF64,m,r)
-        B = rand(ComplexF64,n,r)
-        R  = RkMatrix(A,B);
-        Ra  = adjoint(R);
-        M  = A*adjoint(B)
-        Ma  = adjoint(M)
+        A = rand(ComplexF64, m, r)
+        B = rand(ComplexF64, n, r)
+        R = RkMatrix(A, B)
+        Ra = adjoint(R)
+        M = A * adjoint(B)
+        Ma = adjoint(M)
 
         ## basic tests
-        @test size(R) == (m,n)
+        @test size(R) == (m, n)
         @test rank(R) == r
         @test Matrix(R) ≈ M
-        @test compression_ratio(R) ≈ m*n / (r*(m+n))
-        @test R[:,5] ≈ M[:,5]
-        @test Ra[:,5] ≈ Ma[:,5]
+        @test compression_ratio(R) ≈ m * n / (r * (m + n))
+        @test R[:, 5] ≈ M[:, 5]
+        @test Ra[:, 5] ≈ Ma[:, 5]
     end
 
     @testset "Matrix entries" begin
@@ -30,12 +30,12 @@ using HMatrices: RkMatrix, compression_ratio
         n = 30
         r = 10
         T = SMatrix{3,3,ComplexF64,9}
-        A = rand(T,m,r)
-        B = rand(T,n,r)
-        R  = RkMatrix(A,B)
+        A = rand(T, m, r)
+        B = rand(T, n, r)
+        R = RkMatrix(A, B)
         ## basic tests
-        @test size(R) == (m,n)
+        @test size(R) == (m, n)
         @test rank(R) == r
-        @test compression_ratio(R) ≈ m*n / (r*(m+n))
+        @test compression_ratio(R) ≈ m * n / (r * (m + n))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,19 +1,35 @@
 using SafeTestsets
 
-@safetestset "Utils" begin include("utils_test.jl") end
+@safetestset "Utils" begin
+    include("utils_test.jl")
+end
 
-@safetestset "RkMatrix" begin include("rkmatrix_test.jl") end
+@safetestset "RkMatrix" begin
+    include("rkmatrix_test.jl")
+end
 
-@safetestset "Compressors" begin include("compressor_test.jl") end
+@safetestset "Compressors" begin
+    include("compressor_test.jl")
+end
 
-@safetestset "HMatrix" begin include("hmatrix_test.jl") end
+@safetestset "HMatrix" begin
+    include("hmatrix_test.jl")
+end
 
-@safetestset "Addition" begin include("addition_test.jl") end
+@safetestset "Addition" begin
+    include("addition_test.jl")
+end
 
-@safetestset "Multiplication" begin include("multiplication_test.jl") end
+@safetestset "Multiplication" begin
+    include("multiplication_test.jl")
+end
 
-@safetestset "Triangular" begin include("triangular_test.jl") end
+@safetestset "Triangular" begin
+    include("triangular_test.jl")
+end
 
-@safetestset "LU" begin include("lu_test.jl") end
+@safetestset "LU" begin
+    include("lu_test.jl")
+end
 
 # @safetestset "DHMatrix" begin include("dhmatrix_test.jl") end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -12,8 +12,8 @@ function laplace_matrix(X, Y)
         d = norm(x - y) + EPS
         inv(4π * d)
     end
-    KernelMatrix(f, X, Y)
-    end
+    return KernelMatrix(f, X, Y)
+end
 
 function helmholtz_matrix(X, Y, k)
     f = (x, y) -> begin
@@ -21,7 +21,7 @@ function helmholtz_matrix(X, Y, k)
         d = norm(x - y) + EPS
         exp(im * k * d) * inv(4π * d)
     end
-    KernelMatrix(f, X, Y)
+    return KernelMatrix(f, X, Y)
 end
 
 function elastostatic_matrix(X, Y, μ, λ)
@@ -32,7 +32,7 @@ function elastostatic_matrix(X, Y, μ, λ)
         RRT = r * transpose(r) # r ⊗ rᵗ
         return 1 / (16π * μ * (1 - ν) * d) * ((3 - 4 * ν) * I + RRT / d^2)
     end
-    KernelMatrix(f, X, Y)
+    return KernelMatrix(f, X, Y)
 end
 
 function elastosdynamic_matrix(X, Y, μ, λ, ω, ρ)
@@ -40,17 +40,18 @@ function elastosdynamic_matrix(X, Y, μ, λ, ω, ρ)
         c1 = sqrt((λ + 2μ) / ρ)
         c2 = sqrt(μ / ρ)
         r = x - y
-        d   = norm(r) + EPS
+        d = norm(r) + EPS
         RRT = r * transpose(r) # r ⊗ rᵗ
-        s   = -im * ω
-        z1  = s * d / c1
-        z2  = s * d / c2
-        α   = 4
-        ψ   = exp(-z2) / d + (1 + z2) / (z2^2) * exp(-z2) / d - c2^2 / c1^2 * (1 + z1) / (z1^2) * exp(-z1) / d
+        s = -im * ω
+        z1 = s * d / c1
+        z2 = s * d / c2
+        α = 4
+        ψ = exp(-z2) / d + (1 + z2) / (z2^2) * exp(-z2) / d -
+            c2^2 / c1^2 * (1 + z1) / (z1^2) * exp(-z1) / d
         chi = 3 * ψ - 2 * exp(-z2) / d - c2^2 / c1^2 * exp(-z1) / d
         return 1 / (α * π * μ) * (ψ * I - chi * RRT / d^2) + x * transpose(y)
     end
-    KernelMatrix(f, X, Y)
+    return KernelMatrix(f, X, Y)
 end
 
 """
@@ -63,22 +64,23 @@ struct LaplaceMatrixVec{T,Td} <: AbstractKernelMatrix{T}
     Y::Matrix{Td}
     function LaplaceMatrixVec{T}(X::Matrix{Td}, Y::Matrix{Td}) where {T,Td}
         @assert size(X, 2) == size(Y, 2) == 3
-        new{T,Td}(X, Y)
+        return new{T,Td}(X, Y)
     end
 end
 
 Base.size(K::LaplaceMatrixVec) = size(K.X, 1), size(K.Y, 1)
 
 # constructor based on Vector of StaticVector
-function LaplaceMatrixVec{T}(_X::Vector{SVector{3,Td}}, _Y::Vector{SVector{3,Td}}) where {T,Td}
-    X = reshape(reinterpret(Td, _X), 3, :) |> transpose |> collect
-    Y = reshape(reinterpret(Td, _Y), 3, :) |> transpose |> collect
-    LaplaceMatrixVec{T}(X, Y)
+function LaplaceMatrixVec{T}(_X::Vector{SVector{3,Td}},
+                             _Y::Vector{SVector{3,Td}}) where {T,Td}
+    X = collect(transpose(reshape(reinterpret(Td, _X), 3, :)))
+    Y = collect(transpose(reshape(reinterpret(Td, _Y), 3, :)))
+    return LaplaceMatrixVec{T}(X, Y)
 end
 LaplaceMatrixVec(args...) = LaplaceMatrixVec{Float64}(args...) # default to Float64
 
 function Base.getindex(K::LaplaceMatrixVec{T}, i::Int, j::Int)::T where {T}
-    d2 = (K.X[i,1] - K.Y[j,1])^2 + (K.X[i,2] - K.Y[j,2])^2 + (K.X[i,3] - K.Y[j,3])^2
+    d2 = (K.X[i, 1] - K.Y[j, 1])^2 + (K.X[i, 2] - K.Y[j, 2])^2 + (K.X[i, 3] - K.Y[j, 3])^2
     d = sqrt(d2) + EPS
     return inv(4π * d)
 end
@@ -91,21 +93,21 @@ function Base.getindex(K::LaplaceMatrixVec, I::UnitRange, J::UnitRange)
     out = Matrix{T}(undef, m, n)
     @avx for j in 1:n
         for i in 1:m
-            d2 = (Xv[i,1] - Yv[j,1])^2
-            d2 += (Xv[i,2] - Yv[j,2])^2
-            d2 += (Xv[i,3] - Yv[j,3])^2
+            d2 = (Xv[i, 1] - Yv[j, 1])^2
+            d2 += (Xv[i, 2] - Yv[j, 2])^2
+            d2 += (Xv[i, 3] - Yv[j, 3])^2
             d = sqrt(d2) + EPS
-            out[i,j] = inv(4 * π * d)
+            out[i, j] = inv(4 * π * d)
         end
     end
     return out
 end
 function Base.getindex(K::LaplaceMatrixVec, I::UnitRange, j::Int)
-    return vec(K[I,j:j])
+    return vec(K[I, j:j])
 end
 function Base.getindex(adjK::Adjoint{<:Any,LaplaceMatrixVec}, I::UnitRange, j::Int)
     K = parent(adjK)
-    vec(K[j:j,I])
+    return vec(K[j:j, I])
 end
 
 """
@@ -119,25 +121,27 @@ struct HelmholtzMatrixVec{T,Td,Tk} <: AbstractKernelMatrix{T}
     k::Tk
     function HelmholtzMatrixVec{T}(X::Matrix{Td}, Y::Matrix{Td}, k::Tk) where {T,Td,Tk}
         @assert size(X, 2) == size(Y, 2) == 3
-        new{T,Td,Tk}(X, Y, k)
+        return new{T,Td,Tk}(X, Y, k)
     end
 end
 HelmholtzMatrixVec(args...) = HelmholtzMatrixVec{ComplexF64}(args...)
 
 Base.size(K::HelmholtzMatrixVec) = size(K.X, 1), size(K.Y, 1)
 
-function HelmholtzMatrixVec{T}(_X::Vector{SVector{3,Td}}, _Y::Vector{SVector{3,Td}}, k) where {T,Td}
-    X = reshape(reinterpret(Td, _X), 3, :) |> transpose |> collect
-    Y = reshape(reinterpret(Td, _Y), 3, :) |> transpose |> collect
-    HelmholtzMatrixVec{T}(X, Y, k)
+function HelmholtzMatrixVec{T}(_X::Vector{SVector{3,Td}}, _Y::Vector{SVector{3,Td}},
+                               k) where {T,Td}
+    X = collect(transpose(reshape(reinterpret(Td, _X), 3, :)))
+    Y = collect(transpose(reshape(reinterpret(Td, _Y), 3, :)))
+    return HelmholtzMatrixVec{T}(X, Y, k)
 end
 
 function Base.getindex(K::HelmholtzMatrixVec{T}, i::Int, j::Int)::T where {T}
-    d2 = (K.X[i,1] - K.Y[j,1])^2 + (K.X[i,2] - K.Y[j,2])^2 + (K.X[i,3] - K.Y[j,3])^2
-    d  = sqrt(d2) + EPS
+    d2 = (K.X[i, 1] - K.Y[j, 1])^2 + (K.X[i, 2] - K.Y[j, 2])^2 + (K.X[i, 3] - K.Y[j, 3])^2
+    d = sqrt(d2) + EPS
     return inv(4π * d) * exp(im * K.k * d)
 end
-function Base.getindex(K::HelmholtzMatrixVec{Complex{T}}, I::UnitRange, J::UnitRange) where {T}
+function Base.getindex(K::HelmholtzMatrixVec{Complex{T}}, I::UnitRange,
+                       J::UnitRange) where {T}
     k = K.k
     m = length(I)
     n = length(J)
@@ -146,55 +150,55 @@ function Base.getindex(K::HelmholtzMatrixVec{Complex{T}}, I::UnitRange, J::UnitR
     # since LoopVectorization does not (yet) support Complex{T} types, we will
     # reinterpret the output as a Matrix{T}, then use views. This can probably be
     # done better.
-    out    = Matrix{Complex{T}}(undef, m, n)
-    out_T  = reinterpret(T, out)
-    out_r = @views out_T[1:2:end,:]
-    out_i = @views out_T[2:2:end,:]
+    out = Matrix{Complex{T}}(undef, m, n)
+    out_T = reinterpret(T, out)
+    out_r = @views out_T[1:2:end, :]
+    out_i = @views out_T[2:2:end, :]
     @avx for j in 1:n
         for i in 1:m
-            d2 = (Xv[i,1] - Yv[j,1])^2
-            d2 += (Xv[i,2] - Yv[j,2])^2
-            d2 += (Xv[i,3] - Yv[j,3])^2
-            d  = sqrt(d2) + EPS
+            d2 = (Xv[i, 1] - Yv[j, 1])^2
+            d2 += (Xv[i, 2] - Yv[j, 2])^2
+            d2 += (Xv[i, 3] - Yv[j, 3])^2
+            d = sqrt(d2) + EPS
             s, c = sincos(k * d)
             zr = inv(4π * d) * c
             zi = inv(4π * d) * s
-            out_r[i,j] = zr
-            out_i[i,j] = zi
+            out_r[i, j] = zr
+            out_i[i, j] = zi
         end
     end
     return out
 end
 function Base.getindex(K::HelmholtzMatrixVec, I::UnitRange, j::Int)
-    vec(K[I,j:j])
+    return vec(K[I, j:j])
 end
 function Base.getindex(adjK::Adjoint{<:Any,<:HelmholtzMatrixVec}, I::UnitRange, j::Int)
     K = parent(adjK)
-    conj!(K[j:j,I]) |> vec
+    return vec(conj!(K[j:j, I]))
 end
 
 function points_on_sphere(npts, R=1)
     theta = π * rand(npts)
-    phi   = 2 * π * rand(npts)
-    x     = @. sin(theta) * cos(phi)
-    y     = @. R * sin(theta) * sin(phi)
-    z     = @. R * cos(theta)
-    data  = vcat(x', y', z')
-    pts = reinterpret(SVector{3,Float64}, vec(data)) |> collect
+    phi = 2 * π * rand(npts)
+    x = @. sin(theta) * cos(phi)
+    y = @. R * sin(theta) * sin(phi)
+    z = @. R * cos(theta)
+    data = vcat(x', y', z')
+    pts = collect(reinterpret(SVector{3,Float64}, vec(data)))
     return pts
 end
 
-function points_on_cylinder(radius,n,shift=SVector(0,0,0))
-    step     = 1.75*π*radius/sqrt(n)
-    result          = Vector{SVector{3,Float64}}(undef,n)
-    length          = 2*π*radius
-    pointsPerCircle = length/step
-    angleStep       = 2*π/pointsPerCircle
-    for i=0:n-1
-        x = radius * cos(angleStep*i)
-        y = radius * sin(angleStep*i)
-        z = step*i/pointsPerCircle
-        result[i+1] = shift + SVector(x,y,z)
+function points_on_cylinder(radius, n, shift=SVector(0, 0, 0))
+    step = 1.75 * π * radius / sqrt(n)
+    result = Vector{SVector{3,Float64}}(undef, n)
+    length = 2 * π * radius
+    pointsPerCircle = length / step
+    angleStep = 2 * π / pointsPerCircle
+    for i in 0:(n - 1)
+        x = radius * cos(angleStep * i)
+        y = radius * sin(angleStep * i)
+        z = step * i / pointsPerCircle
+        result[i + 1] = shift + SVector(x, y, z)
     end
     return result
 end

--- a/test/triangular_test.jl
+++ b/test/triangular_test.jl
@@ -6,74 +6,74 @@ using StaticArrays
 
 using HMatrices: RkMatrix
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 Random.seed!(1)
 
 m = 1000
 T = Float64
-X    = points_on_sphere(m)
-Y    = X
+X = points_on_sphere(m)
+Y = X
 struct ExponentialKernel <: AbstractMatrix{Float64}
     X::Vector{SVector{3,Float64}}
     Y::Vector{SVector{3,Float64}}
 end
-function Base.getindex(K::ExponentialKernel,i::Int,j::Int)
-    x,y = K.X[i], K.Y[j]
-    exp(-norm(x-y))
+function Base.getindex(K::ExponentialKernel, i::Int, j::Int)
+    x, y = K.X[i], K.Y[j]
+    return exp(-norm(x - y))
 end
 Base.size(K::ExponentialKernel) = length(K.X), length(K.Y)
-K = ExponentialKernel(X,X)
+K = ExponentialKernel(X, X)
 
-splitter  = CardinalitySplitter(nmax=50)
-Xclt      = ClusterTree(X,splitter)
-Yclt      = ClusterTree(Y,splitter)
-H = assemble_hmat(K,Xclt,Yclt;threads=false,distributed=false)
-H_full      = Matrix(H;global_index=false)
+splitter = CardinalitySplitter(; nmax=50)
+Xclt = ClusterTree(X, splitter)
+Yclt = ClusterTree(Y, splitter)
+H = assemble_hmat(K, Xclt, Yclt; threads=false, distributed=false)
+H_full = Matrix(H; global_index=false)
 
 @testset "ldiv!" begin
-    B = rand(m,2)
-    R = RkMatrix(rand(m,3),rand(m,3))
+    B = rand(m, 2)
+    R = RkMatrix(rand(m, 3), rand(m, 3))
     R_full = Matrix(R)
 
     ## 3.1
-    exact  = ldiv!(UnitLowerTriangular(H_full),copy(B))
-    approx = ldiv!(UnitLowerTriangular(H),copy(B))
+    exact = ldiv!(UnitLowerTriangular(H_full), copy(B))
+    approx = ldiv!(UnitLowerTriangular(H), copy(B))
     @test exact ≈ approx
 
-    exact  = ldiv!(UpperTriangular(H_full),copy(B))
-    approx = ldiv!(UpperTriangular(H),copy(B))
+    exact = ldiv!(UpperTriangular(H_full), copy(B))
+    approx = ldiv!(UpperTriangular(H), copy(B))
     @test exact ≈ approx
 
     ## 3.2
-    exact  = ldiv!(UnitLowerTriangular(H_full),copy(R_full))
-    approx = ldiv!(UnitLowerTriangular(H),copy(R))
+    exact = ldiv!(UnitLowerTriangular(H_full), copy(R_full))
+    approx = ldiv!(UnitLowerTriangular(H), copy(R))
     @test exact ≈ Matrix(approx)
 
     ## 3.3
-    compressor = PartialACA(;atol=1e-8)
-    exact      = ldiv!(UnitLowerTriangular(H_full),copy(H_full))
-    approx     = ldiv!(UnitLowerTriangular(H),deepcopy(H),compressor)
-    @test exact ≈ Matrix(approx;global_index=false)
+    compressor = PartialACA(; atol=1e-8)
+    exact = ldiv!(UnitLowerTriangular(H_full), copy(H_full))
+    approx = ldiv!(UnitLowerTriangular(H), deepcopy(H), compressor)
+    @test exact ≈ Matrix(approx; global_index=false)
 end
 
 @testset "rdiv!" begin
-    B = rand(2,m)
-    R = RkMatrix(rand(m,3),rand(m,3))
+    B = rand(2, m)
+    R = RkMatrix(rand(m, 3), rand(m, 3))
     R_full = Matrix(R)
     # 3.1
-    exact  = rdiv!(copy(B),UpperTriangular(H_full))
-    approx = rdiv!(copy(B),UpperTriangular(H))
+    exact = rdiv!(copy(B), UpperTriangular(H_full))
+    approx = rdiv!(copy(B), UpperTriangular(H))
     @test exact ≈ approx
 
     ## 3.2
-    exact  = rdiv!(copy(R_full),UpperTriangular(H_full))
-    approx = rdiv!(copy(R),UpperTriangular(H))
+    exact = rdiv!(copy(R_full), UpperTriangular(H_full))
+    approx = rdiv!(copy(R), UpperTriangular(H))
     @test exact ≈ approx
 
     ## 3.3
-    compressor = PartialACA(;atol=1e-10)
-    exact  = rdiv!(deepcopy(H_full),UpperTriangular(H_full))
-    approx = rdiv!(deepcopy(H),UpperTriangular(H),compressor)
-    @test exact ≈ Matrix(approx;global_index=false)
+    compressor = PartialACA(; atol=1e-10)
+    exact = rdiv!(deepcopy(H_full), UpperTriangular(H_full))
+    approx = rdiv!(deepcopy(H), UpperTriangular(H), compressor)
+    @test exact ≈ Matrix(approx; global_index=false)
 end

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -5,11 +5,11 @@ using HMatrices: hilbert_linear_to_cartesian, hilbert_cartesian_to_linear
 @testset "Hilbert points" begin
     # check that hilbert curves spans the lattice, and the inverse is correct
     for n in [2^p for p in 0:3]
-        lattice = Set((i,j) for i in 0:n-1,j in 0:n-1)
-        for d in 0:(n^2-1)
-            x,y = hilbert_linear_to_cartesian(n,d)
-            pop!(lattice,(x,y))
-            @test hilbert_cartesian_to_linear(n,x,y) == d
+        lattice = Set((i, j) for i in 0:(n - 1), j in 0:(n - 1))
+        for d in 0:(n^2 - 1)
+            x, y = hilbert_linear_to_cartesian(n, d)
+            pop!(lattice, (x, y))
+            @test hilbert_cartesian_to_linear(n, x, y) == d
         end
         @test isempty(lattice)
     end


### PR DESCRIPTION
The current `lu` factorization is a bit hacky, and before trying to use `DataFlowTasks` to improve the parallel performance of the factorization it makes sense to factor things up a bit. In particular, this branch simplifies some of the logic involved in the algorithm for the hierarchical multiplication based on a *dry run*, together with the `MulLinearOp` structure which aids in assembling the low-rank approximations without allocating intermediate results. 