### PR TITLE
Port code from `WavePropBase` and drop dependency

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "yas"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,42 @@
+# modified from https://github.com/SciML/DiffEqDocs.jl/tree/master/.github/workflows
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+
+      - uses: actions/checkout@v1
+      - name: Install JuliaFormatter and format
+        # This will use the latest version by default but you can set the version like so:
+        #
+        # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
+        run: |
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
+          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
+      - name: Format check
+        run: |
+          julia -e '
+          out = Cmd(`git diff --name-only`) |> read |> String
+          if out == ""
+              exit(0)
+          else
+              @error "Some files have not been formatted !!!"
+              write(stdout, out)
+              exit(1)
+          end'

--- a/.github/workflows/register.yml
+++ b/.github/workflows/register.yml
@@ -1,0 +1,16 @@
+name: Register Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to register or component to bump
+        required: true
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    permissions:
+        contents: write
+    steps:
+      - uses: julia-actions/RegisterAction@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,1 +1,0 @@
-Luiz M. Faria

--- a/Project.toml
+++ b/Project.toml
@@ -12,14 +12,12 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-WavePropBase = "91c5bd54-65f5-4719-ae3b-9579edfc4a0b"
 
 [compat]
 AbstractTrees = "0.3, 0.4"
 RecipesBase = "1.1"
 StaticArrays = "1.2"
 TimerOutputs = "0.5"
-WavePropBase = "0.2"
 julia = "1.6"
 
 [extras]

--- a/benchmark/make.jl
+++ b/benchmark/make.jl
@@ -1,20 +1,19 @@
 using PkgBenchmark
 
-function postprocess(results,fname="benchs")
+function postprocess(results, fname="benchs")
     # writeresults(joinpath(path,fname),results)
     dir = @__DIR__
-    path = joinpath(dir,"../docs/src")
-    export_markdown(joinpath(path,fname*".md"),results)
+    path = joinpath(dir, "../docs/src")
+    return export_markdown(joinpath(path, fname * ".md"), results)
 end
 
-env = Dict("JULIA_NUM_THREADS" =>4,
-           "OPEN_BLAS_NUM_THREADS" => 1
-           )
+env = Dict("JULIA_NUM_THREADS" => 4,
+           "OPEN_BLAS_NUM_THREADS" => 1)
 
-config = BenchmarkConfig(;juliacmd=`julia -O3`,env)
+config = BenchmarkConfig(; juliacmd=`julia -O3`, env)
 
-dir       = @__DIR__
-retune    = false
-results   = benchmarkpkg("HMatrices",config;retune)
+dir = @__DIR__
+retune = false
+results = benchmarkpkg("HMatrices", config; retune)
 
 postprocess(results)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,26 +4,21 @@ using Documenter
 DocMeta.setdocmeta!(HMatrices, :DocTestSetup, :(using HMatrices); recursive=true)
 
 makedocs(;
-    modules=[HMatrices],
-    authors="Luiz M. Faria <maltezfaria@gmail.com> and contributors",
-    repo="https://github.com/WaveProp/HMatrices.jl/blob/{commit}{path}#{line}",
-    sitename="HMatrices.jl",
-    format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://WaveProp.github.io/HMatrices.jl",
-        assets=String[],
-    ),
-    pages=[
-        "Getting started" => "index.md",
-        "Kernel matrices" => "kernelmatrix.md",
-        "Distributed HMatrix" => "dhmatrix.md",
-        "Notebooks" => "notebooks.md",
-        "Benchmarks" => ["benchs.md"],
-        "References" => "references.md"
-    ],
-)
+         modules=[HMatrices],
+         authors="Luiz M. Faria <maltezfaria@gmail.com> and contributors",
+         repo="https://github.com/WaveProp/HMatrices.jl/blob/{commit}{path}#{line}",
+         sitename="HMatrices.jl",
+         format=Documenter.HTML(;
+                                prettyurls=get(ENV, "CI", "false") == "true",
+                                canonical="https://WaveProp.github.io/HMatrices.jl",
+                                assets=String[]),
+         pages=["Getting started" => "index.md",
+                "Kernel matrices" => "kernelmatrix.md",
+                "Distributed HMatrix" => "dhmatrix.md",
+                "Notebooks" => "notebooks.md",
+                "Benchmarks" => ["benchs.md"],
+                "References" => "references.md"])
 
 deploydocs(;
-    repo="github.com/WaveProp/HMatrices.jl",
-    devbranch="main"
-)
+           repo="github.com/WaveProp/HMatrices.jl",
+           devbranch="main")

--- a/docs/notebooks/vectorization.jl
+++ b/docs/notebooks/vectorization.jl
@@ -6,122 +6,125 @@ using InteractiveUtils
 
 # ╔═╡ 2b4aa264-4145-11ec-0d24-ab437ba0f84e
 begin
-    import Pkg
+    using Pkg: Pkg
     # activate the shared project environment
     Pkg.activate(Base.current_project())
 
-    using HMatrices, Plots, PlutoUI, LinearAlgebra, StaticArrays, WavePropBase, BenchmarkTools, LoopVectorization
-	using WavePropBase: PlotPoints, PlotTree, root_elements
+    using HMatrices, Plots, PlutoUI, LinearAlgebra, StaticArrays, WavePropBase,
+          BenchmarkTools, LoopVectorization
+    using WavePropBase: PlotPoints, PlotTree, root_elements
 end
 
 # ╔═╡ 9efa3b28-900c-4515-8aba-617bce2ddc68
-PlutoUI.TableOfContents(;depth=2)
+PlutoUI.TableOfContents(; depth=2)
 
 # ╔═╡ d1917856-64d1-4dab-9e05-40b1152217d2
 begin
-	const Point3D = SVector{3,Float64}
-	m = 10_000
-	X = Y = [Point3D(sin(θ)cos(ϕ),sin(θ)*sin(ϕ),cos(θ)) for (θ,ϕ) in zip(π*rand(m),2π*rand(m))]
+    const Point3D = SVector{3,Float64}
+    m = 10_000
+    X = Y = [Point3D(sin(θ)cos(ϕ), sin(θ) * sin(ϕ), cos(θ))
+             for (θ, ϕ) in zip(π * rand(m), 2π * rand(m))]
 end
 
 # ╔═╡ bdfebc7a-a7a6-4fa6-8884-b4f86dc55cb3
 begin
-	Xclt = Yclt = ClusterTree(X)
-	plot(PlotTree(),Xclt,mc=:red)
+    Xclt = Yclt = ClusterTree(X)
+    plot(PlotTree(), Xclt; mc=:red)
 end
 
 # ╔═╡ 306d493b-a558-4e1d-bad6-5c295da79e82
 begin
-	function G(x,y) 
-	    d = norm(x-y) + 1e-8
-	    inv(4π*d)
-	end
-	K = KernelMatrix(G,X,Y)
+    function G(x, y)
+        d = norm(x - y) + 1e-8
+        return inv(4π * d)
+    end
+    K = KernelMatrix(G, X, Y)
 end
 
 # ╔═╡ 99041c6a-c12f-4a09-8bfd-cf769fd258a6
-H = assemble_hmat(K,Xclt,Yclt;threads=false)
+H = assemble_hmat(K, Xclt, Yclt; threads=false)
 
 # ╔═╡ 02d89923-e478-4778-8b80-eaa3357a6a8c
-b = @benchmark assemble_hmat($K,$Xclt,$Yclt;threads=false)
+b = @benchmark assemble_hmat($K, $Xclt, $Yclt; threads=false)
 
 # ╔═╡ fca099bf-25c0-4ee8-b3f0-c042c4e5fde3
-begin 
-	Xp = Yp = root_elements(Xclt)
-	Kp = KernelMatrix(G,Xp,Yp)
-	Hp = assemble_hmat(Kp,Xclt,Yclt;threads=false,global_index=false)
+begin
+    Xp = Yp = root_elements(Xclt)
+    Kp = KernelMatrix(G, Xp, Yp)
+    Hp = assemble_hmat(Kp, Xclt, Yclt; threads=false, global_index=false)
 end
 
 # ╔═╡ 37ed939e-1738-4ade-85d7-526c3c4ab536
-bp = @benchmark assemble_hmat($Kp,Xclt,Yclt;threads=false,global_index=false)
+bp = @benchmark assemble_hmat($Kp, Xclt, Yclt; threads=false, global_index=false)
 
 # ╔═╡ c6729646-0b6c-4ea2-b692-62e1e8f6b97c
 begin
-	struct LaplaceMatrixVec <: AbstractKernelMatrix{Float64}
-		X::Matrix{Float64}
-		Y::Matrix{Float64}
-	end
-	Base.size(K::LaplaceMatrixVec) = size(K.X,1), size(K.Y,1)
-	
-	# convenience constructor based on Vector of StaticVector
-	function LaplaceMatrixVec(_X::Vector{Point3D},_Y::Vector{Point3D})
-	    X = reshape(reinterpret(Float64,_X), 3,:) |> transpose |> collect
-	    Y = reshape(reinterpret(Float64,_Y), 3,:) |> transpose |> collect
-	    LaplaceMatrixVec(X,Y)
-	end
-	
-	function Base.getindex(K::LaplaceMatrixVec,i::Int,j::Int)
-	    d2 = (K.X[i,1] - K.Y[j,1])^2 + (K.X[i,2] - K.Y[j,2])^2 + (K.X[i,3] - K.Y[j,3])^2
-	    d = sqrt(d2) + 1e-8
-	    return inv(4π*d)
-	end
-	function Base.getindex(K::LaplaceMatrixVec,I::UnitRange,J::UnitRange)
-	    T = eltype(K)
-	    m = length(I)
-	    n = length(J)
-	    Xv = view(K.X,I,:)
-	    Yv = view(K.Y,J,:)
-	    out = Matrix{T}(undef,m,n)
-	    @turbo for j in 1:n
-	        for i in 1:m
-	            d2 = (Xv[i,1] - Yv[j,1])^2
-	            d2 += (Xv[i,2] - Yv[j,2])^2
-	            d2 += (Xv[i,3] - Yv[j,3])^2
-	            d = sqrt(d2) + 1e-8
-	            out[i,j] = inv(4*π*d)
-	        end
-	    end
-	    return out
-	end
-	function Base.getindex(K::LaplaceMatrixVec,I::UnitRange,j::Int)
-	    T = eltype(K)
-	    m = length(I)
-	    Xv = view(K.X,I,:)
-	    out = Vector{T}(undef,m)
-	    @turbo for i in 1:m
-	            d2 = (Xv[i,1] -  K.Y[j,1])^2
-	            d2 += (Xv[i,2] - K.Y[j,2])^2
-	            d2 += (Xv[i,3] - K.Y[j,3])^2
-	            d = sqrt(d2) + 1e-8
-	            out[i] = inv(4*π*d)
-		end
-	    return out
-	end
-	function Base.getindex(adjK::Adjoint{<:Any,<:LaplaceMatrixVec},I::UnitRange,j::Int)
-		K = parent(adjK)
-	    T = eltype(K)
-	    m = length(I)
-		Yv = view(K.Y,I,:)
-	    out = Vector{T}(undef,m)
-	    @turbo for i in 1:m
-	            d2 = (Yv[i,1] - K.X[j,1])^2
-	            d2 += (Yv[i,2] - K.X[j,2])^2
-	            d2 += (Yv[i,3] - K.X[j,3])^2
-	            d = sqrt(d2) + 1e-8
-	            out[i] = inv(4*π*d)
-		end
-	    return out
-	end
+    struct LaplaceMatrixVec <: AbstractKernelMatrix{Float64}
+        X::Matrix{Float64}
+        Y::Matrix{Float64}
+    end
+    Base.size(K::LaplaceMatrixVec) = size(K.X, 1), size(K.Y, 1)
+
+    # convenience constructor based on Vector of StaticVector
+    function LaplaceMatrixVec(_X::Vector{Point3D}, _Y::Vector{Point3D})
+        X = collect(transpose(reshape(reinterpret(Float64, _X), 3, :)))
+        Y = collect(transpose(reshape(reinterpret(Float64, _Y), 3, :)))
+        return LaplaceMatrixVec(X, Y)
+    end
+
+    function Base.getindex(K::LaplaceMatrixVec, i::Int, j::Int)
+        d2 = (K.X[i, 1] - K.Y[j, 1])^2 + (K.X[i, 2] - K.Y[j, 2])^2 +
+             (K.X[i, 3] - K.Y[j, 3])^2
+        d = sqrt(d2) + 1e-8
+        return inv(4π * d)
+    end
+    function Base.getindex(K::LaplaceMatrixVec, I::UnitRange, J::UnitRange)
+        T = eltype(K)
+        m = length(I)
+        n = length(J)
+        Xv = view(K.X, I, :)
+        Yv = view(K.Y, J, :)
+        out = Matrix{T}(undef, m, n)
+        @turbo for j in 1:n
+            for i in 1:m
+                d2 = (Xv[i, 1] - Yv[j, 1])^2
+                d2 += (Xv[i, 2] - Yv[j, 2])^2
+                d2 += (Xv[i, 3] - Yv[j, 3])^2
+                d = sqrt(d2) + 1e-8
+                out[i, j] = inv(4 * π * d)
+            end
+        end
+        return out
+    end
+    function Base.getindex(K::LaplaceMatrixVec, I::UnitRange, j::Int)
+        T = eltype(K)
+        m = length(I)
+        Xv = view(K.X, I, :)
+        out = Vector{T}(undef, m)
+        @turbo for i in 1:m
+            d2 = (Xv[i, 1] - K.Y[j, 1])^2
+            d2 += (Xv[i, 2] - K.Y[j, 2])^2
+            d2 += (Xv[i, 3] - K.Y[j, 3])^2
+            d = sqrt(d2) + 1e-8
+            out[i] = inv(4 * π * d)
+        end
+        return out
+    end
+    function Base.getindex(adjK::Adjoint{<:Any,<:LaplaceMatrixVec}, I::UnitRange, j::Int)
+        K = parent(adjK)
+        T = eltype(K)
+        m = length(I)
+        Yv = view(K.Y, I, :)
+        out = Vector{T}(undef, m)
+        @turbo for i in 1:m
+            d2 = (Yv[i, 1] - K.X[j, 1])^2
+            d2 += (Yv[i, 2] - K.X[j, 2])^2
+            d2 += (Yv[i, 3] - K.X[j, 3])^2
+            d = sqrt(d2) + 1e-8
+            out[i] = inv(4 * π * d)
+        end
+        return out
+    end
 end
 
 # ╔═╡ 85de3038-88f8-442e-a2cd-5462f9552d12
@@ -209,9 +212,9 @@ The `LaplaceMatrix` struct above has a vectorized implementatio of `getindex` fo
 """
 
 # ╔═╡ 71208d87-a9ed-410e-bad1-f770fc84d4db
-begin 
-	Kv = LaplaceMatrixVec(Xp,Yp)
-	Hv = assemble_hmat(Kv,Xclt,Yclt;global_index=false,threads=false)
+begin
+    Kv = LaplaceMatrixVec(Xp, Yp)
+    Hv = assemble_hmat(Kv, Xclt, Yclt; global_index=false, threads=false)
 end
 
 # ╔═╡ 6eaa63e3-755d-482a-a113-98312b6f6fb1
@@ -220,7 +223,7 @@ Benchmarking the new implementation yields:
 """
 
 # ╔═╡ 59fda22e-0547-4845-9207-31c7b526d2f6
-bv = @benchmark assemble_hmat($Kv,Xclt,Yclt;threads=false,global_index=false)
+bv = @benchmark assemble_hmat($Kv, Xclt, Yclt; threads=false, global_index=false)
 
 # ╔═╡ 0b967aaf-271c-4153-acd6-2e5acff8dc75
 md"""
@@ -228,7 +231,7 @@ Comparing the times we see that the vectorized implementation is the fastest, an
 """
 
 # ╔═╡ afc737f1-3523-413f-a73a-96a909580047
-minimum(b),minimum(bp),minimum(bv)
+minimum(b), minimum(bp), minimum(bv)
 
 # ╔═╡ 44f08eda-b5d3-40d0-aa8b-3cae9e137854
 md"""
@@ -237,14 +240,14 @@ Finally, not that as expected all of these yield the same matrix, as indicated b
 
 # ╔═╡ 5fd9b390-ea5f-425c-a624-0cd4a146a897
 begin
-	x = rand(m)
-	y  = H*x
-	yv = Hv*x
-	yp = Hp*x
-	er = max(norm(y-yv)/norm(y),norm(y-yp)/norm(y))
-	md"""
-	Maximum error: $er
-	"""
+    x = rand(m)
+    y = H * x
+    yv = Hv * x
+    yp = Hp * x
+    er = max(norm(y - yv) / norm(y), norm(y - yp) / norm(y))
+    md"""
+    Maximum error: $er
+    """
 end
 
 # ╔═╡ Cell order:

--- a/src/HMatrices.jl
+++ b/src/HMatrices.jl
@@ -1,10 +1,10 @@
 module HMatrices
 
-const PROJECT_ROOT =  pkgdir(HMatrices)
+const PROJECT_ROOT = pkgdir(HMatrices)
 
 using StaticArrays
 using LinearAlgebra
-using Statistics:median
+using Statistics: median
 using TimerOutputs
 using Printf
 using RecipesBase
@@ -12,7 +12,7 @@ using Distributed
 using Base.Threads
 using AbstractTrees: print_tree
 
-import AbstractTrees
+using AbstractTrees: AbstractTrees
 import LinearAlgebra: mul!, lu!, lu, LU, ldiv!, rdiv!, axpy!, rank, rmul!, lmul!
 import Base: Matrix, adjoint, parent
 
@@ -55,28 +55,28 @@ include("triangular.jl")
 include("lu.jl")
 
 export
-    # types (re-exported)
-    CardinalitySplitter,
-    ClusterTree,
-    DyadicSplitter,
-    GeometricSplitter,
-    GeometricMinimalSplitter,
-    HyperRectangle,
-    # abstract types
-    AbstractKernelMatrix,
-    # types
-    HMatrix,
-    KernelMatrix,
-    StrongAdmissibilityStd,
-    WeakAdmissibilityStd,
-    PartialACA,
-    ACA,
-    TSVD,
-    # functions
-    compression_ratio,
-    print_tree,
-    assemble_hmat,
-    # macros
-    @hprofile
+# types (re-exported)
+      CardinalitySplitter,
+      ClusterTree,
+      DyadicSplitter,
+      GeometricSplitter,
+      GeometricMinimalSplitter,
+      HyperRectangle,
+# abstract types
+      AbstractKernelMatrix,
+# types
+      HMatrix,
+      KernelMatrix,
+      StrongAdmissibilityStd,
+      WeakAdmissibilityStd,
+      PartialACA,
+      ACA,
+      TSVD,
+# functions
+      compression_ratio,
+      print_tree,
+      assemble_hmat,
+# macros
+      @hprofile
 
 end

--- a/src/HMatrices.jl
+++ b/src/HMatrices.jl
@@ -10,31 +10,11 @@ using Printf
 using RecipesBase
 using Distributed
 using Base.Threads
-
-import WavePropBase:
-    ClusterTree,
-    CardinalitySplitter,
-    DyadicSplitter,
-    GeometricSplitter,
-    GeometricMinimalSplitter,
-    HyperRectangle,
-    AbstractTree,
-    filter_tree,
-    isleaf,
-    children,
-    parent,
-    index_range,
-    container,
-    center,
-    diameter,
-    distance,
-    root_elements,
-    loc2glob
-
+using AbstractTrees: print_tree
 
 import AbstractTrees
 import LinearAlgebra: mul!, lu!, lu, LU, ldiv!, rdiv!, axpy!, rank, rmul!, lmul!
-import Base: Matrix, adjoint
+import Base: Matrix, adjoint, parent
 
 """
     const ALLOW_GETINDEX
@@ -47,7 +27,7 @@ const ALLOW_GETINDEX = Ref(true)
 """
     use_threads()::Bool
 
-Default choice of whether threads will be used or not throught the package.
+Default choice of whether threads will be used or not throughout the package.
 """
 use_threads() = true
 
@@ -60,6 +40,9 @@ throughout the package.
 use_global_index() = true
 
 include("utils.jl")
+include("hyperrectangle.jl")
+include("clustertree.jl")
+include("splitter.jl")
 include("kernelmatrix.jl")
 include("rkmatrix.jl")
 include("compressor.jl")

--- a/src/addition.jl
+++ b/src/addition.jl
@@ -15,100 +15,100 @@ simply be assigned `X`. This means that after the call `axpy(a,X,Y)`, the object
 `Y` is in a *dirty* state (see [`isclean`][@ref]) and usually a call to
 [`flush_to_leaves!`](@ref) or [`flush_to_children!`](@ref) follows.
 """
-function axpy!(a,X::Matrix,Y::RkMatrix)
-    axpy!(a,RkMatrix(X),Y)
+function axpy!(a, X::Matrix, Y::RkMatrix)
+    return axpy!(a, RkMatrix(X), Y)
 end
 
 # 1.3
-function axpy!(a,X::Matrix,Y::HMatrix)
+function axpy!(a, X::Matrix, Y::HMatrix)
     if hasdata(Y)
-        axpy!(a,X,data(Y))
+        axpy!(a, X, data(Y))
     else
-        setdata!(Y,a*X)
+        setdata!(Y, a * X)
     end
     return Y
 end
 
 # 2.1
-function axpy!(a,X::RkMatrix,Y::Matrix)
-    axpy!(a,Matrix(X),Y)
+function axpy!(a, X::RkMatrix, Y::Matrix)
+    return axpy!(a, Matrix(X), Y)
 end
 
 #2.2
-function axpy!(a,X::RkMatrix,Y::RkMatrix)
-    Y.A   = hcat(a*X.A,Y.A)
-    Y.B   = hcat(X.B,Y.B)
+function axpy!(a, X::RkMatrix, Y::RkMatrix)
+    Y.A = hcat(a * X.A, Y.A)
+    Y.B = hcat(X.B, Y.B)
     return Y
 end
 
 # 2.3
-function axpy!(a,X::RkMatrix,Y::HMatrix)
+function axpy!(a, X::RkMatrix, Y::HMatrix)
     if hasdata(Y)
-        axpy!(a,X,data(Y))
+        axpy!(a, X, data(Y))
     else
-        setdata!(Y,a*X)
+        setdata!(Y, a * X)
     end
     return Y
 end
 
 #3.1
-function axpy!(a,X::HMatrix,Y::Matrix)
+function axpy!(a, X::HMatrix, Y::Matrix)
     @debug "calling axpy! with `X` and HMatrix and `Y` a Matrix"
     shift = pivot(X) .- 1
     for block in AbstractTrees.PreOrderDFS(X)
         irange = rowrange(block) .- shift[1]
         jrange = colrange(block) .- shift[2]
         if hasdata(block)
-            axpy!(a,data(block),view(Y,irange,jrange))
+            axpy!(a, data(block), view(Y, irange, jrange))
         end
     end
     return Y
 end
 
 # 3.2
-function axpy!(a,X::HMatrix,Y::RkMatrix)
+function axpy!(a, X::HMatrix, Y::RkMatrix)
     @debug "calling axpby! with `X` and HMatrix and `Y` an RkMatrix"
     # FIXME: inneficient implementation due to conversion from HMatrix to
     # Matrix. Does it really matter? I don't think this function should be
     # called.
-    axpy!(a,Matrix(X;global_index=false),Y)
+    return axpy!(a, Matrix(X; global_index=false), Y)
 end
 
 # 3.3
-function axpy!(a,X::HMatrix,Y::HMatrix)
+function axpy!(a, X::HMatrix, Y::HMatrix)
     # TODO: assumes X and Y have the same structure. How to reinforce this?
     if hasdata(X)
         if hasdata(Y)
-            axpy!(a,data(X),Y)
+            axpy!(a, data(X), Y)
         else
-            setdata!(Y,a*data(X))
+            setdata!(Y, a * data(X))
         end
     end
     @assert size(children(X)) == size(children(Y)) "adding hierarchical matrices requires identical block structure"
-    for (bx,by) in zip(children(X),children(Y))
-        axpy!(a,bx,by)
+    for (bx, by) in zip(children(X), children(Y))
+        axpy!(a, bx, by)
     end
     return Y
 end
 
 # add a unifor scaling to an HMatrix return an HMatrix
-function axpy!(a,X::UniformScaling,Y::HMatrix)
+function axpy!(a, X::UniformScaling, Y::HMatrix)
     @assert isclean(Y)
     if hasdata(Y)
         d = data(Y)
         @assert d isa Matrix
         n = min(size(d)...)
-        for i=1:n
-            d[i,i] += a*X.λ
+        for i in 1:n
+            d[i, i] += a * X.λ
         end
     else
         n = min(blocksize(Y)...)
-        for i=1:n
-            axpy!(a,X,children(Y)[i,i])
+        for i in 1:n
+            axpy!(a, X, children(Y)[i, i])
         end
     end
     return Y
 end
 
-Base.:(+)(X::UniformScaling,Y::HMatrix) = axpy!(true,X,deepcopy(Y))
-Base.:(+)(X::HMatrix,Y::UniformScaling) = Y+X
+Base.:(+)(X::UniformScaling, Y::HMatrix) = axpy!(true, X, deepcopy(Y))
+Base.:(+)(X::HMatrix, Y::UniformScaling) = Y + X

--- a/src/clustertree.jl
+++ b/src/clustertree.jl
@@ -1,0 +1,163 @@
+"""
+    mutable struct ClusterTree{N,T}
+
+Tree structure used to cluster poitns of type `SVector{N,T}` into [`HyperRectangle`](@ref)s.
+
+# Fields:
+- `_elements::Vector{SVector{N,T}}` : vector containing the sorted elements.
+- `container::HyperRectangle{N,T}` : container for the elements in the current node.
+- `index_range::UnitRange{Int}` : indices of elements contained in the current node.
+- `loc2glob::Vector{Int}` : permutation from the local indexing system to the
+  original (global) indexing system used as input in the construction of the
+  tree.
+- `children::Vector{ClusterTree{N,T}}`
+- `parent::ClusterTree{N,T}`
+"""
+mutable struct ClusterTree{N,T}
+    _elements::Vector{SVector{N,T}}
+    container::HyperRectangle{N,T}
+    index_range::UnitRange{Int}
+    loc2glob::Vector{Int}
+    buffer::Vector{Int}
+    children::Vector{ClusterTree{N,T}}
+    parent::ClusterTree{N,T}
+    function ClusterTree(els::Vector{SVector{N,T}},container,loc_idxs,
+                        loc2glob,buffer,children,parent) where {N,T}
+        clt = new{N,T}(els, container, loc_idxs, loc2glob, buffer)
+        clt.children = isnothing(children) ? Vector{typeof(clt)}() : children
+        clt.parent = isnothing(parent) ? clt : parent
+        return clt
+    end
+end
+
+# convenience functions and getters
+"""
+    root_elements(clt::ClusterTree)
+
+The elements contained in the root of the tree to which `clt` belongs.
+"""
+root_elements(clt::ClusterTree) = clt._elements
+
+"""
+    index_range(clt::ClusterTree)
+
+Indices of elements in `root_elements(clt)` which lie inside `clt`.
+"""
+index_range(clt::ClusterTree) = clt.index_range
+
+children(clt::ClusterTree) = clt.children
+
+"""
+    parent(t::ClusterTree)
+
+The node's parent. If `t` is a root, then `parent(t)==t`.
+"""
+parent(clt::ClusterTree) = clt.parent
+
+"""
+    container(clt::ClusterTree)
+
+Return the object enclosing all the elements of the `clt`.
+"""
+container(clt::ClusterTree) = clt.container
+
+"""
+    elements(clt::ClusterTree)
+
+Iterable list of the elements inside `clt`.
+"""
+elements(clt::ClusterTree) = view(root_elements(clt), index_range(clt))
+
+"""
+    loc2glob(clt::ClusterTree)
+
+The permutation from the (local) indexing system of the elements of the `clt` to
+the (global) indexes used upon the construction of the tree.
+"""
+loc2glob(clt::ClusterTree) = clt.loc2glob
+
+buffer(clt::ClusterTree) = clt.buffer
+
+isleaf(clt::ClusterTree) = isempty(clt.children)
+isroot(clt::ClusterTree) = clt.parent == clt
+
+# for compatibility with AbstractTrees
+AbstractTrees.children(t::ClusterTree) = isleaf(t) ? () : t.children
+AbstractTrees.childrentype(::Type{T}) where {T<:ClusterTree} = Vector{T}
+
+diameter(node::ClusterTree) = diameter(container(node))
+radius(node::ClusterTree) = radius(container(node))
+
+"""
+    distance(X::ClusterTree, Y::ClusterTree)
+
+Distance between the containers of `X` and `Y`.
+"""
+function distance(node1::ClusterTree, node2::ClusterTree)
+    return distance(container(node1), container(node2))
+end
+
+Base.length(node::ClusterTree) = length(index_range(node))
+
+"""
+    ClusterTree(elements,splitter;[copy_elements=true, threads=false])
+
+Construct a `ClusterTree` from the  given `elements` using the splitting
+strategy encoded in `splitter`. If `copy_elements` is set to false, the
+`elements` argument are directly stored in the `ClusterTree` and are permuted
+during the tree construction.
+"""
+function ClusterTree(elements, splitter=CardinalitySplitter();
+                    copy_elements=true,
+                    threads=false)
+    copy_elements && (elements = deepcopy(elements))
+    bbox = bounding_box(elements)
+    n = length(elements)
+    irange = 1:n
+    loc2glob = collect(irange)
+    buffer   = collect(irange)
+    children = nothing
+    parent   = nothing
+    #build the root, then recurse
+    root = ClusterTree(elements, bbox, irange, loc2glob, buffer, children, parent)
+    _build_cluster_tree!(root, splitter, threads)
+    # finally, permute the elements so as to use the local indexing
+    copy!(elements, elements[loc2glob]) # faster than permute!
+    return root
+end
+
+function _build_cluster_tree!(current_node, splitter, threads, depth=0)
+    if should_split(current_node, depth, splitter)
+        split!(current_node, splitter)
+        if threads
+            Threads.@threads for child in children(current_node)
+                _build_cluster_tree!(child, splitter, threads, depth + 1)
+            end
+        else
+            for child in children(current_node)
+                _build_cluster_tree!(child, splitter, threads, depth + 1)
+            end
+        end
+    end
+    return current_node
+end
+
+
+
+function Base.show(io::IO, tree::ClusterTree{N,T}) where {N,T}
+    return print(io, "ClusterTree with $(length(tree.index_range)) points.")
+end
+
+function Base.summary(clt::ClusterTree)
+    @printf "Cluster tree with %i elements" length(clt)
+    nodes = collect(AbstractTrees.PreOrderDFS(clt))
+    @printf "\n\t number of nodes: %i" length(nodes)
+    leaves = collect(AbstractTrees.Leaves(clt))
+    @printf "\n\t number of leaves: %i" length(leaves)
+    points_per_leaf = map(length, leaves)
+    @printf "\n\t min number of elements per leaf: %i" minimum(points_per_leaf)
+    @printf "\n\t max number of elements per leaf: %i" maximum(points_per_leaf)
+    depth_per_leaf = map(depth, leaves)
+    @printf "\n\t min depth of leaves: %i" minimum(depth_per_leaf)
+    @printf "\n\t max depth of leaves: %i" maximum(depth_per_leaf)
+end

--- a/src/clustertree.jl
+++ b/src/clustertree.jl
@@ -21,8 +21,8 @@ mutable struct ClusterTree{N,T}
     buffer::Vector{Int}
     children::Vector{ClusterTree{N,T}}
     parent::ClusterTree{N,T}
-    function ClusterTree(els::Vector{SVector{N,T}},container,loc_idxs,
-                        loc2glob,buffer,children,parent) where {N,T}
+    function ClusterTree(els::Vector{SVector{N,T}}, container, loc_idxs,
+                         loc2glob, buffer, children, parent) where {N,T}
         clt = new{N,T}(els, container, loc_idxs, loc2glob, buffer)
         clt.children = isnothing(children) ? Vector{typeof(clt)}() : children
         clt.parent = isnothing(parent) ? clt : parent
@@ -108,16 +108,16 @@ strategy encoded in `splitter`. If `copy_elements` is set to false, the
 during the tree construction.
 """
 function ClusterTree(elements, splitter=CardinalitySplitter();
-                    copy_elements=true,
-                    threads=false)
+                     copy_elements=true,
+                     threads=false)
     copy_elements && (elements = deepcopy(elements))
     bbox = bounding_box(elements)
     n = length(elements)
     irange = 1:n
     loc2glob = collect(irange)
-    buffer   = collect(irange)
+    buffer = collect(irange)
     children = nothing
-    parent   = nothing
+    parent = nothing
     #build the root, then recurse
     root = ClusterTree(elements, bbox, irange, loc2glob, buffer, children, parent)
     _build_cluster_tree!(root, splitter, threads)
@@ -141,8 +141,6 @@ function _build_cluster_tree!(current_node, splitter, threads, depth=0)
     end
     return current_node
 end
-
-
 
 function Base.show(io::IO, tree::ClusterTree{N,T}) where {N,T}
     return print(io, "ClusterTree with $(length(tree.index_range)) points.")

--- a/src/compressor.jl
+++ b/src/compressor.jl
@@ -33,24 +33,24 @@ true
 
 ```
 """
-@Base.kwdef struct ACA
+Base.@kwdef struct ACA
     atol::Float64 = 0
-    rank::Int     = typemax(Int)
-    rtol::Float64 = atol>0 || rank<typemax(Int) ? 0 : sqrt(eps(Float64))
+    rank::Int = typemax(Int)
+    rtol::Float64 = atol > 0 || rank < typemax(Int) ? 0 : sqrt(eps(Float64))
 end
 
-function (aca::ACA)(K,rowtree::ClusterTree,coltree::ClusterTree)
+function (aca::ACA)(K, rowtree::ClusterTree, coltree::ClusterTree)
     irange = index_range(rowtree)
     jrange = index_range(coltree)
-    aca(K,irange,jrange)
+    return aca(K, irange, jrange)
 end
 
-function (aca::ACA)(K,irange,jrange)
-    M  = K[irange,jrange] # computes the entire matrix.
-    _aca_full!(M,aca.atol,aca.rank,aca.rtol)
+function (aca::ACA)(K, irange, jrange)
+    M = K[irange, jrange] # computes the entire matrix.
+    return _aca_full!(M, aca.atol, aca.rank, aca.rtol)
 end
 
-(comp::ACA)(K::Matrix) = comp(K,1:size(K,1),1:size(K,2))
+(comp::ACA)(K::Matrix) = comp(K, 1:size(K, 1), 1:size(K, 2))
 
 """
     _aca_full!(M,atol,rmax,rtol)
@@ -60,35 +60,35 @@ full pivoting. The matrix `M` is modified in place. The returned `RkMatrix` has
 rank at most `rmax`, and is expected to satisfy `|M - R| < max(atol,rtol*|M|)`.
 """
 function _aca_full!(M, atol, rmax, rtol)
-    Madj  = adjoint(M)
-    T   = eltype(M)
-    m,n = size(M)
-    A   = Vector{Vector{T}}()
-    B   = Vector{Vector{T}}()
+    Madj = adjoint(M)
+    T = eltype(M)
+    m, n = size(M)
+    A = Vector{Vector{T}}()
+    B = Vector{Vector{T}}()
     er = Inf
-    exact_norm = norm(M,2) # exact norm
+    exact_norm = norm(M, 2) # exact norm
     r = 0 # current rank
-    while er > max(atol,rtol*exact_norm) && r < rmax
+    while er > max(atol, rtol * exact_norm) && r < rmax
         I = _aca_full_pivot(M)
-        i,j = Tuple(I)
-        δ   = M[I]
+        i, j = Tuple(I)
+        δ = M[I]
         if svdvals(δ)[end] == 0
-            return RkMatrix(A,B)
+            return RkMatrix(A, B)
         else
             iδ = inv(δ)
-            col  = M[:,j]
-            adjcol  = Madj[:,i]
+            col = M[:, j]
+            adjcol = Madj[:, i]
             for k in eachindex(adjcol)
-                adjcol[k] = adjcol[k]*adjoint(iδ)
+                adjcol[k] = adjcol[k] * adjoint(iδ)
             end
             r += 1
-            push!(A,col)
-            push!(B,adjcol)
-            axpy!(-1,col*adjoint(adjcol),M) # M <-- M - col*row'
-            er = norm(M,2) # exact error
+            push!(A, col)
+            push!(B, adjcol)
+            axpy!(-1, col * adjoint(adjcol), M) # M <-- M - col*row'
+            er = norm(M, 2) # exact error
         end
     end
-    return RkMatrix(A,B)
+    return RkMatrix(A, B)
 end
 
 """
@@ -118,26 +118,26 @@ evaluated at every `i,j`. This is usually much faster than [`ACA`](@ref), but
 due to the pivoting strategy the algorithm may fail in special cases, even when
 the underlying linear operator is of low rank.
 """
-@Base.kwdef struct PartialACA
+Base.@kwdef struct PartialACA
     atol::Float64 = 0
-    rank::Int     = typemax(Int)
-    rtol::Float64 = atol>0 || rank<typemax(Int) ? 0 : sqrt(eps(Float64))
+    rank::Int = typemax(Int)
+    rtol::Float64 = atol > 0 || rank < typemax(Int) ? 0 : sqrt(eps(Float64))
 end
 
-function (paca::PartialACA)(K,rowtree::ClusterTree,coltree::ClusterTree)
+function (paca::PartialACA)(K, rowtree::ClusterTree, coltree::ClusterTree)
     # find initial column pivot for partial ACA
     istart = _aca_partial_initial_pivot(rowtree)
     irange = index_range(rowtree)
     jrange = index_range(coltree)
-    _aca_partial(K,irange,jrange,paca.atol,paca.rank,paca.rtol,istart-irange.start+1)
+    return _aca_partial(K, irange, jrange, paca.atol, paca.rank, paca.rtol,
+                        istart - irange.start + 1)
 end
 
-function (paca::PartialACA)(K,irange::UnitRange,jrange::UnitRange)
-    _aca_partial(K,irange,jrange,paca.atol,paca.rank,paca.rtol)
+function (paca::PartialACA)(K, irange::UnitRange, jrange::UnitRange)
+    return _aca_partial(K, irange, jrange, paca.atol, paca.rank, paca.rtol)
 end
 
-(paca::PartialACA)(K::Matrix) = paca(K,1:size(K,1),1:size(K,2))
-
+(paca::PartialACA)(K::Matrix) = paca(K, 1:size(K, 1), 1:size(K, 2))
 
 """
     _aca_partial(K,irange,jrange,atol,rmax,rtol,istart=1)
@@ -148,73 +148,73 @@ partial pivoting. The returned `R::RkMatrix` provides an approximation to
 max(atol,rtol*|M|)`, but this inequality may fail to hold due to the various
 errors involved in estimating the error and |M|.
 """
-function _aca_partial(K,irange,jrange,atol,rmax,rtol,istart=1)
+function _aca_partial(K, irange, jrange, atol, rmax, rtol, istart=1)
     Kadj = adjoint(K)
     # if irange and jrange are Colon, extract the size from `K` directly. This
     # allows for some code reuse with specializations on getindex(i,::Colon) and
     # getindex(::Colon,j) for when `K` is a `RkMatrix`
     if irange isa Colon && jrange isa Colon
-        m,n = size(K)
-        ishift,jshift = 0,0
+        m, n = size(K)
+        ishift, jshift = 0, 0
     else
-        m,n = length(irange), length(jrange)
-        ishift,jshift = irange.start-1, jrange.start-1
+        m, n = length(irange), length(jrange)
+        ishift, jshift = irange.start - 1, jrange.start - 1
         # maps global indices to local indices
     end
-    rmax = min(m,n,rmax)
-    T   = Base.eltype(K)
-    A   = Vector{Vector{T}}()
-    B   = Vector{Vector{T}}()
-    I   = BitVector(true for i = 1:m)
-    J   = BitVector(true for i = 1:n)
-    i   = istart # initial pivot
-    er  = Inf
+    rmax = min(m, n, rmax)
+    T = Base.eltype(K)
+    A = Vector{Vector{T}}()
+    B = Vector{Vector{T}}()
+    I = BitVector(true for i in 1:m)
+    J = BitVector(true for i in 1:n)
+    i = istart # initial pivot
+    er = Inf
     est_norm = 0 # approximate norm of K[irange,jrange]
-    r   = 0 # current rank
-    while er > max(atol,rtol*est_norm) && r < rmax
+    r = 0 # current rank
+    while er > max(atol, rtol * est_norm) && r < rmax
         # remove index i from allowed row
         I[i] = false
         # compute next row by row <-- K[i+ishift,jrange] - R[i,:]
-        adjcol = Kadj[jrange,i+ishift]
-        for k = 1:r
-            axpy!(-adjoint(A[k][i]),B[k],adjcol)
+        adjcol = Kadj[jrange, i + ishift]
+        for k in 1:r
+            axpy!(-adjoint(A[k][i]), B[k], adjcol)
             # for j in eachindex(row)
             #     row[j] = row[j] - B[k][j]*adjoint(A[k][i])
             # end
         end
-        j    = _aca_partial_pivot(adjcol,J)
-        δ    = adjcol[j]
+        j = _aca_partial_pivot(adjcol, J)
+        δ = adjcol[j]
         if svdvals(δ)[end] == 0
             @debug "zero pivot found during partial aca"
-            i = findfirst(x->x==true,I)
+            i = findfirst(x -> x == true, I)
         else # δ != 0
             iδ = inv(δ)
             # rdiv!(b,δ) # b <-- b/δ
             for k in eachindex(adjcol)
-                adjcol[k] = adjcol[k]*iδ
+                adjcol[k] = adjcol[k] * iδ
             end
             J[j] = false
             # compute next col by col <-- K[irange,j+jshift] - R[:,j]
-            col    = K[irange,j+jshift]
-            for k = 1:r
-                axpy!(-adjoint(B[k][j]),A[k],col)
+            col = K[irange, j + jshift]
+            for k in 1:r
+                axpy!(-adjoint(B[k][j]), A[k], col)
                 # for i in eachindex(col)
                 #     col[i] = col[i] - A[k][i]*adjoint(B[k][j])
                 # end
             end
             # push new cross and increase rank
             r += 1
-            push!(A,col)
-            push!(B,adjcol)
+            push!(A, col)
+            push!(B, adjcol)
             # estimate the error by || R_{k} - R_{k-1} || = ||a|| ||b||
-            er       = norm(col)*norm(adjcol)
+            er = norm(col) * norm(adjcol)
             # estimate the norm by || K || ≈ || R_k ||
-            est_norm = _update_frob_norm(est_norm,A,B)
-            i        = _aca_partial_pivot(col,I)
+            est_norm = _update_frob_norm(est_norm, A, B)
+            i = _aca_partial_pivot(col, I)
             # @show r, er
         end
     end
-    return RkMatrix(A,B)
+    return RkMatrix(A, B)
 end
 
 """
@@ -223,14 +223,14 @@ end
 Given the Frobenius norm of `Rₖ = A[1:end-1]*adjoint(B[1:end-1])` in `acc`,
 compute the Frobenius norm of `Rₖ₊₁ = A*adjoint(B)` efficiently.
 """
-@inline function _update_frob_norm(cur,A,B)
+@inline function _update_frob_norm(cur, A, B)
     @timeit_debug "Update Frobenius norm" begin
         k = length(A)
         a = A[end]
         b = B[end]
         out = norm(a)^2 * norm(b)^2
-        for l=1:k-1
-            out += 2*real(dot(A[l],a)*(dot(b,B[l])))
+        for l in 1:(k - 1)
+            out += 2 * real(dot(A[l], a) * (dot(b, B[l])))
         end
     end
     return sqrt(cur^2 + out)
@@ -250,13 +250,13 @@ kernels; see
 (https://www.sciencedirect.com/science/article/pii/S0021999117306721)[https://www.sciencedirect.com/science/article/pii/S0021999117306721]
 for more details.
 """
-function _aca_partial_pivot(v,J)
+function _aca_partial_pivot(v, J)
     idx = -1
     val = -Inf
     for n in 1:length(J)
         J[n] || continue
-        x   = v[n]
-        σ   = svdvals(x)[end]
+        x = v[n]
+        σ = svdvals(x)[end]
         σ < val && continue
         idx = n
         val = σ
@@ -276,11 +276,11 @@ When `x` is a scalar, this is simply the element with largest absolute value.
 """
 function _aca_full_pivot(M)
     idxs = CartesianIndices(M)
-    idx  = first(idxs)
+    idx = first(idxs)
     val = -Inf
     for I in idxs
-        x   = M[I]
-        σ   = svdvals(x)[end]
+        x = M[I]
+        σ = svdvals(x)[end]
         σ < val && continue
         idx = I
         val = σ
@@ -292,15 +292,15 @@ function _aca_partial_initial_pivot(rowtree)
     # the method below is suggested in Bebendorf, but it does not seem to
     # improve the  error. The idea is that the initial pivot is the closesest
     # point to the center of the cluster
-    xc        = center(container(rowtree))
-    d         = Inf
-    els       = root_elements(rowtree)
-    loc_idxs  = index_range(rowtree)
-    istart    = first(loc_idxs)
+    xc = center(container(rowtree))
+    d = Inf
+    els = root_elements(rowtree)
+    loc_idxs = index_range(rowtree)
+    istart = first(loc_idxs)
     for i in loc_idxs
-        x     = els[i]
-        if norm(x-xc) < d
-            d      = norm(x-xc)
+        x = els[i]
+        if norm(x - xc) < d
+            d = norm(x - xc)
             istart = i
         end
     end
@@ -314,24 +314,24 @@ Compression algorithm based on *a posteriori* truncation of an `SVD`. This is
 the optimal approximation in Frobenius norm; however, it also tends to be very
 expensive and thus should be used mostly for "small" matrices.
 """
-@Base.kwdef struct TSVD
+Base.@kwdef struct TSVD
     atol::Float64 = 0
-    rank::Int     = typemax(Int)
-    rtol::Float64 = atol>0 || rank<typemax(Int) ? 0 : sqrt(eps(Float64))
+    rank::Int = typemax(Int)
+    rtol::Float64 = atol > 0 || rank < typemax(Int) ? 0 : sqrt(eps(Float64))
 end
 
-function (tsvd::TSVD)(K,rowtree::ClusterTree,coltree::ClusterTree)
+function (tsvd::TSVD)(K, rowtree::ClusterTree, coltree::ClusterTree)
     irange = index_range(rowtree)
     jrange = index_range(coltree)
-    tsvd(K,irange,jrange)
+    return tsvd(K, irange, jrange)
 end
 
-function (tsvd::TSVD)(K,irange::UnitRange,jrange::UnitRange)
-    M = K[irange,jrange]
-    compress!(M,tsvd)
+function (tsvd::TSVD)(K, irange::UnitRange, jrange::UnitRange)
+    M = K[irange, jrange]
+    return compress!(M, tsvd)
 end
 
-(comp::TSVD)(K::Matrix) = comp(K,1:size(K,1),1:size(K,2))
+(comp::TSVD)(K::Matrix) = comp(K, 1:size(K, 1), 1:size(K, 2))
 
 """
     compress!(M::RkMatrix,tsvd::TSVD)
@@ -340,26 +340,26 @@ Recompress the matrix `R` using a truncated svd of `R`. The implementation uses
 the `qr-svd` strategy to efficiently compute `svd(R)` when `rank(R) ≪
 min(size(R))`.
 """
-function compress!(R::RkMatrix,tsvd::TSVD)
-    m,n   = size(R)
+function compress!(R::RkMatrix, tsvd::TSVD)
+    m, n = size(R)
     QA, RA = qr!(R.A)
     QB, RB = qr!(R.B)
-    F      = svd!(RA*adjoint(RB)) # svd of an r×r problem
-    U      = QA*F.U
-    Vt     = F.Vt*adjoint(QB)
-    V      = adjoint(Vt)
+    F = svd!(RA * adjoint(RB)) # svd of an r×r problem
+    U = QA * F.U
+    Vt = F.Vt * adjoint(QB)
+    V = adjoint(Vt)
     sp_norm = F.S[1] # spectral norm
-    r     = findlast(x -> x>max(tsvd.atol,tsvd.rtol*sp_norm), F.S)
-    isnothing(r) && (r = min(rank(R),m,n))
-    r = min(r,tsvd.rank)
-    if m<n
-        A = @views U[:,1:r]*Diagonal(F.S[1:r])
-        B = V[:,1:r]
+    r = findlast(x -> x > max(tsvd.atol, tsvd.rtol * sp_norm), F.S)
+    isnothing(r) && (r = min(rank(R), m, n))
+    r = min(r, tsvd.rank)
+    if m < n
+        A = @views U[:, 1:r] * Diagonal(F.S[1:r])
+        B = V[:, 1:r]
     else
-        A = U[:,1:r]
-        B = @views (V[:,1:r])*Diagonal(F.S[1:r])
+        A = U[:, 1:r]
+        B = @views (V[:, 1:r]) * Diagonal(F.S[1:r])
     end
-    R.A,R.B = A,B
+    R.A, R.B = A, B
     return R
 end
 
@@ -369,19 +369,19 @@ end
 Recompress the matrix `M` using a truncated svd and output an `RkMatrix`. The
 data in `M` is invalidated in the process.
 """
-function compress!(M::Matrix,tsvd::TSVD)
-    m,n = size(M)
-    F      = svd!(M)
+function compress!(M::Matrix, tsvd::TSVD)
+    m, n = size(M)
+    F = svd!(M)
     sp_norm = F.S[1] # spectral norm
-    r     = findlast(x -> x>max(tsvd.atol,tsvd.rtol*sp_norm), F.S)
-    isnothing(r) && (r = min(m,n))
-    r = min(r,tsvd.rank)
-    if m<n
-        A = @views F.U[:,1:r]*Diagonal(F.S[1:r])
-        B = F.V[:,1:r]
+    r = findlast(x -> x > max(tsvd.atol, tsvd.rtol * sp_norm), F.S)
+    isnothing(r) && (r = min(m, n))
+    r = min(r, tsvd.rank)
+    if m < n
+        A = @views F.U[:, 1:r] * Diagonal(F.S[1:r])
+        B = F.V[:, 1:r]
     else
-        A = F.U[:,1:r]
-        B = @views (F.V[:,1:r])*Diagonal(F.S[1:r])
+        A = F.U[:, 1:r]
+        B = @views (F.V[:, 1:r]) * Diagonal(F.S[1:r])
     end
-    return RkMatrix(A,B)
+    return RkMatrix(A, B)
 end

--- a/src/dhmatrix.jl
+++ b/src/dhmatrix.jl
@@ -3,8 +3,8 @@ using Distributed
 function typeof_future(r::Future)
     if isready(r)
         pid = r.where
-        f   = @spawnat pid typeof(fetch(r))
-        T   = fetch(f)
+        f = @spawnat pid typeof(fetch(r))
+        T = fetch(f)
         return T
     else
         error("future is not ready")
@@ -23,9 +23,9 @@ end
 
 Base.fetch(r::RemoteHMatrix) = fetch(r.future)
 
-function Base.getindex(r::RemoteHMatrix,i::Int,j::Int)
+function Base.getindex(r::RemoteHMatrix, i::Int, j::Int)
     pid = r.future.where
-    @fetchfrom pid getindex(fetch(r),i,j)
+    @fetchfrom pid getindex(fetch(r), i, j)
 end
 
 """
@@ -46,10 +46,10 @@ mutable struct DHMatrix{R,T} <: AbstractHMatrix{T}
     children::Matrix{DHMatrix{R,T}}
     parent::DHMatrix{R,T}
     # inner constructor which handles `nothing` fields.
-    function DHMatrix{R,T}(rowtree,coltree,data,children,parent) where {R,T}
-        dhmat = new{R,T}(rowtree,coltree,data)
-        dhmat.children = isnothing(children) ? Matrix{DHMatrix{R,T}}(undef,0,0) : children
-        dhmat.parent   = isnothing(parent) ? dhmat : parent
+    function DHMatrix{R,T}(rowtree, coltree, data, children, parent) where {R,T}
+        dhmat = new{R,T}(rowtree, coltree, data)
+        dhmat.children = isnothing(children) ? Matrix{DHMatrix{R,T}}(undef, 0, 0) : children
+        dhmat.parent = isnothing(parent) ? dhmat : parent
         return dhmat
     end
 end
@@ -65,22 +65,24 @@ for distributed computing. Currently, the only available options is
 `distribute_columns`, which will partition the columns of the underlying matrix
 into `floor(log2(nw))` parts, where `nw` is the number of workers available.
 """
-function DHMatrix{T}(rowtree::R, coltree::R; partition_strategy=:distribute_columns) where {R,T}
+function DHMatrix{T}(rowtree::R, coltree::R;
+                     partition_strategy=:distribute_columns) where {R,T}
     #build root
-    root  = DHMatrix{R,T}(rowtree,coltree,nothing,nothing,nothing)
+    root = DHMatrix{R,T}(rowtree, coltree, nothing, nothing, nothing)
     # depending on the partition strategy, dispatch to appropriate (recursive)
     # method
     if partition_strategy == :distribute_columns
-        nw        = nworkers()
-        dmax      = floor(Int64,log2(nw))
-        _build_block_structure_distribute_cols!(root,dmax)
+        nw = nworkers()
+        dmax = floor(Int64, log2(nw))
+        _build_block_structure_distribute_cols!(root, dmax)
     else
         error("unrecognized partition strategy")
     end
     return root
 end
 
-function _build_block_structure_distribute_cols!(current_node::DHMatrix{R,T},dmax) where {R,T}
+function _build_block_structure_distribute_cols!(current_node::DHMatrix{R,T},
+                                                 dmax) where {R,T}
     if Trees.depth(current_node) == dmax
         return current_node
     else
@@ -90,10 +92,11 @@ function _build_block_structure_distribute_cols!(current_node::DHMatrix{R,T},dma
         # do not recurse on row, only on columns
         row_children = [X]
         col_children = Y.children
-        children     = [DHMatrix{R,T}(r,c,nothing,nothing,current_node) for r in row_children, c in col_children]
+        children = [DHMatrix{R,T}(r, c, nothing, nothing, current_node)
+                    for r in row_children, c in col_children]
         current_node.children = children
         for child in children
-            _build_block_structure_distribute_cols!(child,dmax)
+            _build_block_structure_distribute_cols!(child, dmax)
         end
         return current_node
     end
@@ -101,17 +104,18 @@ end
 
 Base.size(H::DHMatrix) = length(rowrange(H)), length(colrange(H))
 
-function Base.show(io::IO,::MIME"text/plain",hmat::DHMatrix)
+function Base.show(io::IO, ::MIME"text/plain", hmat::DHMatrix)
     # isclean(hmat) || return print(io,"Dirty DHMatrix")
-    println(io,"Distributed HMatrix of $(eltype(hmat)) with range $(rowrange(hmat)) × $(colrange(hmat))")
+    println(io,
+            "Distributed HMatrix of $(eltype(hmat)) with range $(rowrange(hmat)) × $(colrange(hmat))")
     nodes = collect(AbstractTrees.PreOrderDFS(hmat))
-    println(io,"\t number of nodes in tree: $(length(nodes))")
+    println(io, "\t number of nodes in tree: $(length(nodes))")
     leaves = collect(AbstractTrees.Leaves(hmat))
-    @printf(io,"\t number of leaves: %i\n",length(leaves))
-    for (i,leaf) in enumerate(leaves)
-        r   = leaf.data.future
+    @printf(io, "\t number of leaves: %i\n", length(leaves))
+    for (i, leaf) in enumerate(leaves)
+        r = leaf.data.future
         pid = r.where
-        irange,jrange = @fetchfrom pid rowrange(fetch(r)), colrange(fetch(r))
+        irange, jrange = @fetchfrom pid rowrange(fetch(r)), colrange(fetch(r))
         println("\t\t leaf $i on process $pid spanning $irange × $jrange")
     end
 end
@@ -122,58 +126,61 @@ end
 Internal methods called **after** the `DHMatrix` structure has been initialized
 in order to construct the `HMatrix` on each of the leaves of the `DHMatrix`.
 """
-function _assemble_hmat_distributed(K,rtree,ctree;adm=StrongAdmissibilityStd(),comp=PartialACA(),
-                                    global_index=use_global_index(),threads=use_threads())
+function _assemble_hmat_distributed(K, rtree, ctree; adm=StrongAdmissibilityStd(),
+                                    comp=PartialACA(),
+                                    global_index=use_global_index(), threads=use_threads())
     #
     R = typeof(rtree)
     T = eltype(K)
-    wids   = workers()
-    root   = DHMatrix{T}(rtree,ctree;partition_strategy=:distribute_columns)
-    leaves = AbstractTrees.Leaves(root) |> collect
+    wids = workers()
+    root = DHMatrix{T}(rtree, ctree; partition_strategy=:distribute_columns)
+    leaves = collect(AbstractTrees.Leaves(root))
     @info "Assembling distributed HMatrix on $(length(leaves)) processes"
     @sync for (k, leaf) in enumerate(leaves)
         pid = wids[k] # id of k-th worker
-        r   = @spawnat pid assemble_hmat(K, rowtree(leaf), coltree(leaf); adm, comp,global_index,threads,distributed=false)
+        r = @spawnat pid assemble_hmat(K, rowtree(leaf), coltree(leaf); adm, comp,
+                                       global_index, threads, distributed=false)
         leaf.data = RemoteHMatrix{R,T}(r)
     end
     return root
 end
 
-function mul!(y::AbstractVector,A::DHMatrix,x::AbstractVector,a::Number,b::Number;
-                            global_index=use_global_index(),threads=use_threads())
+function mul!(y::AbstractVector, A::DHMatrix, x::AbstractVector, a::Number, b::Number;
+              global_index=use_global_index(), threads=use_threads())
     # since the HMatrix represents A = Pr*H*Pc, where Pr and Pc are row and column
     # permutations, we need first to rewrite C <-- b*C + a*(Pc*H*Pb)*B as
     # C <-- Pr*(b*inv(Pr)*C + a*H*(Pc*B)). Following this rewrite, the
     # multiplication is performed by first defining B <-- Pc*B, and C <--
     # inv(Pr)*C, doing the multiplication with the permuted entries, and then
     # permuting the result  C <-- Pr*C at the end.
-    ctree     = A.coltree
-    rtree     = A.rowtree
+    ctree = A.coltree
+    rtree = A.rowtree
     # permute input
     if global_index
-        x         = x[ctree.loc2glob]
-        y         = permute!(y,rtree.loc2glob)
-        rmul!(x,a) # multiply in place since this is a new copy, so does not mutate exterior x
+        x = x[ctree.loc2glob]
+        y = permute!(y, rtree.loc2glob)
+        rmul!(x, a) # multiply in place since this is a new copy, so does not mutate exterior x
     else
-        x = a*x # new copy of x
+        x = a * x # new copy of x
     end
-    rmul!(y,b)
-    leaves = filter_tree(x->Trees.isleaf(x),A)
-    nb  = length(leaves)
-    acc = Vector{Future}(undef,nb)
+    rmul!(y, b)
+    leaves = filter_tree(x -> Trees.isleaf(x), A)
+    nb = length(leaves)
+    acc = Vector{Future}(undef, nb)
     @sync for i in 1:nb
-        r        = leaves[i].data.future
-        pid      = r.where
-        jrange   = @fetchfrom pid colrange(fetch(r))
-        T,n      = eltype(y), length(y)
-        acc[i] = @spawnat pid mul!(zeros(T,n),fetch(r),view(x,jrange),1,0;global_index=false,threads)
+        r = leaves[i].data.future
+        pid = r.where
+        jrange = @fetchfrom pid colrange(fetch(r))
+        T, n = eltype(y), length(y)
+        acc[i] = @spawnat pid mul!(zeros(T, n), fetch(r), view(x, jrange), 1, 0;
+                                   global_index=false, threads)
     end
     # reduction stage: fetch everybody to worker 1 and sum them up
     for yi in acc
-        axpy!(1,fetch(yi),y)
+        axpy!(1, fetch(yi), y)
     end
     # permute output
-    global_index && invpermute!(y,loc2glob(rtree))
+    global_index && invpermute!(y, loc2glob(rtree))
     return y
 end
 

--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -1,6 +1,6 @@
-abstract type  AbstractHMatrix{T} <: AbstractMatrix{T} end
+abstract type AbstractHMatrix{T} <: AbstractMatrix{T} end
 
-function Base.getindex(H::AbstractHMatrix,i,j)
+function Base.getindex(H::AbstractHMatrix, i, j)
     # NOTE: you may disable `getindex` to avoid having code that will work, but be
     # horribly slow because it falls back to some generic implementation in
     # LinearAlgebra. The downside is that the `show` method, which will usually
@@ -15,25 +15,25 @@ function Base.getindex(H::AbstractHMatrix,i,j)
     `AbstractHMatrix` has fallen back to a generic implementation.
     """
     if ALLOW_GETINDEX[]
-        shift = pivot(H) .-1
-        _getindex(H,i+shift[1],j+shift[2])
+        shift = pivot(H) .- 1
+        _getindex(H, i + shift[1], j + shift[2])
     else
         error(msg)
     end
 end
 
-function _getindex(H,i,j)
-    (i ∈ rowrange(H)) && (j ∈ colrange(H)) || throw(BoundsError(H,(i,j)))
+function _getindex(H, i, j)
+    (i ∈ rowrange(H)) && (j ∈ colrange(H)) || throw(BoundsError(H, (i, j)))
     acc = zero(eltype(H))
     shift = pivot(H) .- 1
     if hasdata(H)
         il = i - shift[1]
         jl = j - shift[2]
-        acc  += data(H)[il,jl]
+        acc += data(H)[il, jl]
     end
     for child in children(H)
         if (i ∈ rowrange(child)) && (j ∈ colrange(child))
-            acc += _getindex(child,i,j)
+            acc += _getindex(child, i, j)
         end
     end
     return acc
@@ -53,96 +53,95 @@ mutable struct HMatrix{R,T} <: AbstractHMatrix{T}
     children::Matrix{HMatrix{R,T}}
     parent::HMatrix{R,T}
     # inner constructor which handles `nothing` fields.
-    function HMatrix{R,T}(rowtree,coltree,adm,data,children,parent) where {R,T}
+    function HMatrix{R,T}(rowtree, coltree, adm, data, children, parent) where {R,T}
         if data !== nothing
-            @assert (length(rowtree),length(coltree)) === size(data) "$(length(rowtree)),$(length(coltree)) != $(size(data))"
+            @assert (length(rowtree), length(coltree)) === size(data) "$(length(rowtree)),$(length(coltree)) != $(size(data))"
         end
-        hmat = new{R,T}(rowtree,coltree,adm,data)
-        hmat.children = isnothing(children) ? Matrix{HMatrix{R,T}}(undef,0,0) : children
-        hmat.parent   = isnothing(parent) ? hmat : parent
+        hmat = new{R,T}(rowtree, coltree, adm, data)
+        hmat.children = isnothing(children) ? Matrix{HMatrix{R,T}}(undef, 0, 0) : children
+        hmat.parent = isnothing(parent) ? hmat : parent
         return hmat
     end
 end
 
 # setters and getters (defined for AbstractHMatrix)
-isadmissible(H::AbstractHMatrix)  = H.admissible
-hasdata(H::AbstractHMatrix)       = !isnothing(H.data)
-data(H::AbstractHMatrix)          = H.data
-setdata!(H::AbstractHMatrix,d) = setfield!(H,:data,d)
+isadmissible(H::AbstractHMatrix) = H.admissible
+hasdata(H::AbstractHMatrix) = !isnothing(H.data)
+data(H::AbstractHMatrix) = H.data
+setdata!(H::AbstractHMatrix, d) = setfield!(H, :data, d)
 rowtree(H::AbstractHMatrix) = H.rowtree
 coltree(H::AbstractHMatrix) = H.coltree
 
 cluster_type(::HMatrix{R,T}) where {R,T} = R
 
-Base.getindex(H::HMatrix,::Colon,j) = getcol(H,j)
+Base.getindex(H::HMatrix, ::Colon, j) = getcol(H, j)
 
 # getcol for regular matrices
-function getcol!(col,M::Matrix,j)
-    @assert length(col) == size(M,1)
-    copyto!(col,view(M,:,j))
+function getcol!(col, M::Matrix, j)
+    @assert length(col) == size(M, 1)
+    return copyto!(col, view(M, :, j))
 end
-function getcol!(col,adjM::Adjoint{<:Any,<:Matrix},j)
-    @assert length(col) == size(adjM,1)
-    copyto!(col,view(adjM,:,j))
-end
-
-getcol(M::Matrix,j) = M[:,j]
-getcol(adjM::Adjoint{<:Any,<:Matrix},j) = adjM[:,j]
-
-
-function getcol(H::HMatrix,j::Int)
-    m,n = size(H)
-    T   = eltype(H)
-    col = zeros(T,m)
-    getcol!(col,H,j)
+function getcol!(col, adjM::Adjoint{<:Any,<:Matrix}, j)
+    @assert length(col) == size(adjM, 1)
+    return copyto!(col, view(adjM, :, j))
 end
 
-function getcol!(col,H::HMatrix,j::Int)
+getcol(M::Matrix, j) = M[:, j]
+getcol(adjM::Adjoint{<:Any,<:Matrix}, j) = adjM[:, j]
+
+function getcol(H::HMatrix, j::Int)
+    m, n = size(H)
+    T = eltype(H)
+    col = zeros(T, m)
+    return getcol!(col, H, j)
+end
+
+function getcol!(col, H::HMatrix, j::Int)
     (j ∈ colrange(H)) || throw(BoundsError())
     piv = pivot(H)
-    _getcol!(col,H,j,piv)
+    return _getcol!(col, H, j, piv)
 end
 
-function _getcol!(col,H::HMatrix,j,piv)
+function _getcol!(col, H::HMatrix, j, piv)
     if hasdata(H)
-        shift        = pivot(H) .- 1
-        jl           = j - shift[2]
-        irange       = rowrange(H) .- (piv[1] - 1)
-        getcol!(view(col,irange),data(H),jl)
+        shift = pivot(H) .- 1
+        jl = j - shift[2]
+        irange = rowrange(H) .- (piv[1] - 1)
+        getcol!(view(col, irange), data(H), jl)
     end
     for child in children(H)
         if j ∈ colrange(child)
-            _getcol!(col,child,j,piv)
+            _getcol!(col, child, j, piv)
         end
     end
     return col
 end
 
-Base.getindex(adjH::Adjoint{<:Any,<:HMatrix},::Colon,j) = getcol(adjH,j)
+Base.getindex(adjH::Adjoint{<:Any,<:HMatrix}, ::Colon, j) = getcol(adjH, j)
 
-function getcol(adjH::Adjoint{<:Any,<:HMatrix},j::Int)
+function getcol(adjH::Adjoint{<:Any,<:HMatrix}, j::Int)
     # (j ∈ colrange(adjH)) || throw(BoundsError())
-    m,n = size(adjH)
-    T   = eltype(adjH)
-    col = zeros(T,m)
-    getcol!(col,adjH,j)
+    m, n = size(adjH)
+    T = eltype(adjH)
+    col = zeros(T, m)
+    return getcol!(col, adjH, j)
 end
 
-function getcol!(col,adjH::Adjoint{<:Any,<:HMatrix},j::Int)
+function getcol!(col, adjH::Adjoint{<:Any,<:HMatrix}, j::Int)
     piv = pivot(adjH)
-    _getcol!(col,adjH,j,piv)
+    return _getcol!(col, adjH, j, piv)
 end
 
-function _getcol!(col,adjH::Adjoint{<:Any,<:HMatrix},j,piv)
+function _getcol!(col, adjH::Adjoint{<:Any,<:HMatrix}, j, piv)
     if hasdata(adjH)
-        shift        = pivot(adjH) .- 1
-        jl           = j - shift[2]
-        irange       = rowrange(adjH) .- (piv[1] - 1)
-        getcol!(view(col,irange),data(adjH),jl)
+        shift = pivot(adjH) .- 1
+        jl = j - shift[2]
+        irange = rowrange(adjH) .- (piv[1] - 1)
+        getcol!(view(col, irange), data(adjH), jl)
     end
     for child in children(adjH)
         if j ∈ colrange(child)
-            _getcol!(col,child,j,piv)
+            _getcol!(col, child, j, piv)
         end
     end
     return col
@@ -150,28 +149,28 @@ end
 
 # Trees interface
 children(H::AbstractHMatrix) = H.children
-children(H::AbstractHMatrix,idxs...) = H.children[idxs]
-parent(H::AbstractHMatrix)   = H.parent
-isleaf(H::AbstractHMatrix)   = isempty(children(H))
-isroot(H::AbstractHMatrix)   = parent(H) === H
+children(H::AbstractHMatrix, idxs...) = H.children[idxs]
+parent(H::AbstractHMatrix) = H.parent
+isleaf(H::AbstractHMatrix) = isempty(children(H))
+isroot(H::AbstractHMatrix) = parent(H) === H
 
 # interface to AbstractTrees. No children is determined by an empty tuple for
 # AbstractTrees.
 AbstractTrees.children(t::AbstractHMatrix) = isleaf(t) ? () : t.children
 AbstractTrees.nodetype(t::AbstractHMatrix) = typeof(t)
 
-rowrange(H::AbstractHMatrix)         = index_range(H.rowtree)
-colrange(H::AbstractHMatrix)         = index_range(H.coltree)
-rowperm(H::AbstractHMatrix)          =  H |> rowtree |> loc2glob
-colperm(H::AbstractHMatrix)          =  H |> coltree |> loc2glob
-pivot(H::AbstractHMatrix)            = (rowrange(H).start,colrange(H).start)
-offset(H::AbstractHMatrix)           = pivot(H) .- 1
+rowrange(H::AbstractHMatrix) = index_range(H.rowtree)
+colrange(H::AbstractHMatrix) = index_range(H.coltree)
+rowperm(H::AbstractHMatrix) = loc2glob(rowtree(H))
+colperm(H::AbstractHMatrix) = loc2glob(coltree(H))
+pivot(H::AbstractHMatrix) = (rowrange(H).start, colrange(H).start)
+offset(H::AbstractHMatrix) = pivot(H) .- 1
 
 # Base.axes(H::HMatrix) = rowrange(H),colrange(H)
 Base.size(H::AbstractHMatrix) = length(rowrange(H)), length(colrange(H))
 
 function blocksize(H::AbstractHMatrix)
-    size(children(H))
+    return size(children(H))
 end
 
 """
@@ -184,41 +183,44 @@ function compression_ratio(H::HMatrix)
     nr = length(H) # represented entries
     for block in AbstractTrees.Leaves(H)
         data = block.data
-        ns  += num_stored_elements(data)
-   end
-   return nr/ns
+        ns += num_stored_elements(data)
+    end
+    return nr / ns
 end
 
 num_stored_elements(M::Matrix) = length(M)
 
-function Base.show(io::IO,hmat::HMatrix)
-    isclean(hmat) || return print(io,"Dirty HMatrix")
-    print(io,"HMatrix of $(eltype(hmat)) with range $(rowrange(hmat)) × $(colrange(hmat))")
-    _show(io,hmat)
+function Base.show(io::IO, hmat::HMatrix)
+    isclean(hmat) || return print(io, "Dirty HMatrix")
+    print(io, "HMatrix of $(eltype(hmat)) with range $(rowrange(hmat)) × $(colrange(hmat))")
+    _show(io, hmat)
     return io
 end
-Base.show(io::IO,::MIME"text/plain",hmat::HMatrix) = show(io,hmat)
+Base.show(io::IO, ::MIME"text/plain", hmat::HMatrix) = show(io, hmat)
 
-function _show(io,hmat)
+function _show(io, hmat)
     nodes = collect(AbstractTrees.PreOrderDFS(hmat))
     @printf io "\n\t number of nodes in tree: %i" length(nodes)
     leaves = collect(AbstractTrees.Leaves(hmat))
-    sparse_leaves = filter(isadmissible,leaves)
-    dense_leaves  = filter(!isadmissible,leaves)
-    @printf(io,"\n\t number of leaves: %i (%i admissible + %i full)",length(leaves),length(sparse_leaves),
-    length(dense_leaves))
-    rmin,rmax = isempty(sparse_leaves) ? (-1,-1) : extrema(x->rank(x.data),sparse_leaves)
-    @printf(io,"\n\t min rank of sparse blocks : %i",rmin)
-    @printf(io,"\n\t max rank of sparse blocks : %i",rmax)
-    dense_min,dense_max = isempty(dense_leaves) ? (-1,-1) : extrema(x->length(x.data),dense_leaves)
-    @printf(io,"\n\t min length of dense blocks : %i",dense_min)
-    @printf(io,"\n\t max length of dense blocks : %i",dense_max)
-    points_per_leaf = map(length,leaves)
-    @printf(io,"\n\t min number of elements per leaf: %i",minimum(points_per_leaf))
-    @printf(io,"\n\t max number of elements per leaf: %i",maximum(points_per_leaf))
-    depth_per_leaf = map(depth,leaves)
-    @printf(io,"\n\t depth of tree: %i",maximum(depth_per_leaf))
-    @printf(io,"\n\t compression ratio: %f\n",compression_ratio(hmat))
+    sparse_leaves = filter(isadmissible, leaves)
+    dense_leaves = filter(!isadmissible, leaves)
+    @printf(io, "\n\t number of leaves: %i (%i admissible + %i full)", length(leaves),
+            length(sparse_leaves),
+            length(dense_leaves))
+    rmin, rmax = isempty(sparse_leaves) ? (-1, -1) :
+                 extrema(x -> rank(x.data), sparse_leaves)
+    @printf(io, "\n\t min rank of sparse blocks : %i", rmin)
+    @printf(io, "\n\t max rank of sparse blocks : %i", rmax)
+    dense_min, dense_max = isempty(dense_leaves) ? (-1, -1) :
+                           extrema(x -> length(x.data), dense_leaves)
+    @printf(io, "\n\t min length of dense blocks : %i", dense_min)
+    @printf(io, "\n\t max length of dense blocks : %i", dense_max)
+    points_per_leaf = map(length, leaves)
+    @printf(io, "\n\t min number of elements per leaf: %i", minimum(points_per_leaf))
+    @printf(io, "\n\t max number of elements per leaf: %i", maximum(points_per_leaf))
+    depth_per_leaf = map(depth, leaves)
+    @printf(io, "\n\t depth of tree: %i", maximum(depth_per_leaf))
+    @printf(io, "\n\t compression ratio: %f\n", compression_ratio(hmat))
     return io
 end
 
@@ -230,18 +232,18 @@ global indexing system (see [`HMatrix`](@ref) for more information); otherwise
 the *local* indexing system induced by the row and columns trees are used
 (default).
 """
-Matrix(hmat::HMatrix;global_index=true) = Matrix{eltype(hmat)}(hmat;global_index)
-function Base.Matrix{T}(hmat::HMatrix;global_index) where {T}
-    M = zeros(T,size(hmat)...)
+Matrix(hmat::HMatrix; global_index=true) = Matrix{eltype(hmat)}(hmat; global_index)
+function Base.Matrix{T}(hmat::HMatrix; global_index) where {T}
+    M = zeros(T, size(hmat)...)
     piv = pivot(hmat)
     for block in AbstractTrees.PreOrderDFS(hmat)
         hasdata(block) || continue
         irange = rowrange(block) .- piv[1] .+ 1
         jrange = colrange(block) .- piv[2] .+ 1
-        M[irange,jrange] += Matrix(block.data)
+        M[irange, jrange] += Matrix(block.data)
     end
     if global_index
-        P = PermutedMatrix(M,invperm(rowperm(hmat)),invperm(colperm(hmat)))
+        P = PermutedMatrix(M, invperm(rowperm(hmat)), invperm(colperm(hmat)))
         return Matrix(P)
     else
         return M
@@ -263,39 +265,43 @@ It is assumed that `K` supports `getindex(K,i,j)`, and that comp can be called
 as `comp(K,irange::UnitRange,jrange::UnitRange)` to produce a compressed version
 of `K[irange,jrange]` in the form of an [`RkMatrix`](@ref).
 """
-function assemble_hmat(K,rowtree,coltree;adm=StrongAdmissibilityStd(3),comp=PartialACA(),
-                       global_index=use_global_index(),threads=use_threads(),distributed=false)
-    T  = eltype(K)
+function assemble_hmat(K, rowtree, coltree; adm=StrongAdmissibilityStd(3),
+                       comp=PartialACA(),
+                       global_index=use_global_index(), threads=use_threads(),
+                       distributed=false)
+    T = eltype(K)
     if distributed
-        _assemble_hmat_distributed(K,rowtree,coltree;adm,comp,global_index,threads)
+        _assemble_hmat_distributed(K, rowtree, coltree; adm, comp, global_index, threads)
     else
         # create first the structure. No parellelism used as this should be light.
         @timeit_debug "initilizing block structure" begin
-            hmat = HMatrix{T}(rowtree,coltree,adm)
+            hmat = HMatrix{T}(rowtree, coltree, adm)
         end
         # if needed permute kernel entries into indexing induced by trees
-        global_index && (K = PermutedMatrix(K,loc2glob(rowtree),loc2glob(coltree)))
+        global_index && (K = PermutedMatrix(K, loc2glob(rowtree), loc2glob(coltree)))
         # now assemble the data in the blocks
         @timeit_debug "assembling hmatrix" begin
             if threads
                 @info "Assembling HMatrix on $(Threads.nthreads()) threads"
-                _assemble_threads!(hmat,K,comp)
+                _assemble_threads!(hmat, K, comp)
             else
                 @info "Assembling HMatrix on 1 thread"
-                _assemble_cpu!(hmat,K,comp)
+                _assemble_cpu!(hmat, K, comp)
             end
         end
     end
 end
 
-function assemble_hmat(K::AbstractKernelMatrix;atol=0,rank=typemax(Int),rtol=atol>0 || rank<typemax(Int) ? 0 : sqrt(eps(Float64)),kwargs...)
-    comp = PartialACA(;rtol,atol,rank)
-    adm  = StrongAdmissibilityStd(3)
-    X    = rowelements(K)
-    Y    = colelements(K)
+function assemble_hmat(K::AbstractKernelMatrix; atol=0, rank=typemax(Int),
+                       rtol=atol > 0 || rank < typemax(Int) ? 0 : sqrt(eps(Float64)),
+                       kwargs...)
+    comp = PartialACA(; rtol, atol, rank)
+    adm = StrongAdmissibilityStd(3)
+    X = rowelements(K)
+    Y = colelements(K)
     Xclt = ClusterTree(X)
     Yclt = ClusterTree(Y)
-    assemble_hmat(K,Xclt,Yclt;adm,comp,kwargs...)
+    return assemble_hmat(K, Xclt, Yclt; adm, comp, kwargs...)
 end
 
 """
@@ -308,9 +314,9 @@ hierarchical matrix, but **does not compute `data`** field in the blocks. See
 """
 function HMatrix{T}(rowtree::R, coltree::R, adm) where {R,T}
     #build root
-    root  = HMatrix{R,T}(rowtree,coltree,false,nothing,nothing,nothing)
+    root = HMatrix{R,T}(rowtree, coltree, false, nothing, nothing, nothing)
     # recurse
-    _build_block_structure!(adm,root)
+    _build_block_structure!(adm, root)
     return root
 end
 
@@ -324,16 +330,17 @@ function _build_block_structure!(adm, current_node::HMatrix{R,T}) where {R,T}
     Y = current_node.coltree
     if (isleaf(X) || isleaf(Y))
         current_node.admissible = false
-    elseif adm(X,Y)
+    elseif adm(X, Y)
         current_node.admissible = true
     else
         current_node.admissible = false
         row_children = X.children
         col_children = Y.children
-        children     = [HMatrix{R,T}(r,c,false,nothing,nothing,current_node) for r in row_children, c in col_children]
+        children = [HMatrix{R,T}(r, c, false, nothing, nothing, current_node)
+                    for r in row_children, c in col_children]
         current_node.children = children
         for child in children
-            _build_block_structure!(adm,child)
+            _build_block_structure!(adm, child)
         end
     end
     return current_node
@@ -347,17 +354,17 @@ using the compressor `comp`. This function assumes the structure of `hmat` has
 already been intialized, and therefore should not be called directly. See
 [`HMatrix`](@ref) information on constructors.
 """
-function _assemble_cpu!(hmat,K,comp)
+function _assemble_cpu!(hmat, K, comp)
     if isleaf(hmat) # base case
         if isadmissible(hmat)
-            _assemble_sparse_block!(hmat,K,comp)
+            _assemble_sparse_block!(hmat, K, comp)
         else
-            _assemble_dense_block!(hmat,K)
+            _assemble_dense_block!(hmat, K)
         end
     else
         # recurse on children
         for child in hmat.children
-            _assemble_cpu!(child,K,comp)
+            _assemble_cpu!(child, K, comp)
         end
     end
     return hmat
@@ -370,31 +377,31 @@ Like [`_assemble_cpu!`](@ref), but uses threads to assemble the leaves. Note
 that the threads are spanwned using `Threads.@spawn`, which means they are
 spawned on the same worker as the caller.
 """
-function _assemble_threads!(hmat,K,comp)
+function _assemble_threads!(hmat, K, comp)
     # FIXME: ideally something like `omp for schedule(guided)` should be used here
     # to avoid spawning too many (small) tasks. In the absece of such scheduling
     # strategy in julia at the moment (v1.6), we resort to manually limiting the size
     # of the tasks by directly calling the serial method for blocks which are
     # smaller than a given length (1000^2 here).
-    blocks = filter_tree(hmat,true) do x
-        (isleaf(x) || length(x)<1000*1000)
+    blocks = filter_tree(hmat, true) do x
+        return (isleaf(x) || length(x) < 1000 * 1000)
     end
-    sort!(blocks;lt=(x,y)->length(x)<length(y),rev=true)
+    sort!(blocks; lt=(x, y) -> length(x) < length(y), rev=true)
     n = length(blocks)
     @sync for i in 1:n
-        Threads.@spawn _assemble_cpu!(blocks[i],K,comp)
+        Threads.@spawn _assemble_cpu!(blocks[i], K, comp)
     end
     return hmat
 end
 
-function _assemble_sparse_block!(hmat,K,comp)
-    hmat.data = comp(K,hmat.rowtree,hmat.coltree)
+function _assemble_sparse_block!(hmat, K, comp)
+    return hmat.data = comp(K, hmat.rowtree, hmat.coltree)
 end
 
-function _assemble_dense_block!(hmat,K)
+function _assemble_dense_block!(hmat, K)
     irange = rowrange(hmat)
     jrange = colrange(hmat)
-    hmat.data = K[irange,jrange]
+    hmat.data = K[irange, jrange]
     return hmat
 end
 
@@ -409,14 +416,15 @@ isleaf(adjH::Adjoint{<:Any,<:HMatrix}) = isleaf(adjH.parent)
 
 Base.size(adjH::Adjoint{<:Any,<:HMatrix}) = reverse(size(adjH.parent))
 
-function Base.show(io::IO,adjH::Adjoint{<:Any,<:HMatrix})
+function Base.show(io::IO, adjH::Adjoint{<:Any,<:HMatrix})
     hmat = parent(adjH)
-    isclean(hmat) || return print(io,"Dirty HMatrix")
-    print(io,"Adjoint HMatrix of $(eltype(hmat)) with range $(rowrange(adjH)) × $(colrange(adjH))")
-    _show(io,hmat)
+    isclean(hmat) || return print(io, "Dirty HMatrix")
+    print(io,
+          "Adjoint HMatrix of $(eltype(hmat)) with range $(rowrange(adjH)) × $(colrange(adjH))")
+    _show(io, hmat)
     return io
 end
-Base.show(io::IO,::MIME"text/plain",adjH::Adjoint{<:Any,<:HMatrix}) = show(io,adjH)
+Base.show(io::IO, ::MIME"text/plain", adjH::Adjoint{<:Any,<:HMatrix}) = show(io, adjH)
 
 """
     struct StrongAdmissibilityStd
@@ -432,13 +440,13 @@ adm(Xnode,Ynode)
 ```
 """
 Base.@kwdef struct StrongAdmissibilityStd
-    eta::Float64=3.0
+    eta::Float64 = 3.0
 end
 
 function (adm::StrongAdmissibilityStd)(left_node, right_node)
-    diam_min = minimum(diameter,(left_node,right_node))
-    dist     = distance(left_node,right_node)
-    return diam_min < adm.eta*dist
+    diam_min = minimum(diameter, (left_node, right_node))
+    dist = distance(left_node, right_node)
+    return diam_min < adm.eta * dist
 end
 
 """
@@ -450,7 +458,7 @@ between them is positive.
 struct WeakAdmissibilityStd
 end
 
-(adm::WeakAdmissibilityStd)(left_node, right_node) = distance(left_node,right_node) > 0
+(adm::WeakAdmissibilityStd)(left_node, right_node) = distance(left_node, right_node) > 0
 
 """
     isclean(H::HMatrix)
@@ -477,58 +485,57 @@ function isclean(H::HMatrix)
     return true
 end
 
-function depth(tree::HMatrix,acc=0)
+function depth(tree::HMatrix, acc=0)
     if isroot(tree)
         return acc
     else
-        depth(parent(tree),acc+1)
+        depth(parent(tree), acc + 1)
     end
 end
 
 function Base.zero(H::HMatrix)
     H0 = deepcopy(H)
-    rmul!(H0,0)
+    rmul!(H0, 0)
     return H0
 end
 
-function compress!(H::HMatrix,comp)
+function compress!(H::HMatrix, comp)
     @assert isclean(H)
     for leaf in AbstractTrees.Leaves(H)
         d = data(leaf)
         if d isa RkMatrix
-            compress!(d,comp)
+            compress!(d, comp)
         end
     end
     return H
 end
-
 
 ############################################################################################
 # Recipes
 ############################################################################################
 @recipe function f(hmat::HMatrix)
     legend --> false
-    grid   --> false
+    grid --> false
     aspect_ratio --> :equal
-    yflip  := true
+    yflip := true
     seriestype := :shape
-    linecolor  --> :black
+    linecolor --> :black
     # all leaves
     for block in AbstractTrees.Leaves(hmat)
         @series begin
             if isadmissible(block)
-                fillcolor    --> :blue
-                seriesalpha  --> 1/compression_ratio(block.data)
+                fillcolor --> :blue
+                seriesalpha --> 1 / compression_ratio(block.data)
             else
-                fillcolor    --> :red
-                seriesalpha  --> 0.3
+                fillcolor --> :red
+                seriesalpha --> 0.3
             end
             pt1 = pivot(block)
             pt2 = pt1 .+ size(block) .- 1
-            y1, y2 = pt1[1],pt2[1]
-            x1, x2 = pt1[2],pt2[2]
+            y1, y2 = pt1[1], pt2[1]
+            x1, x2 = pt1[2], pt2[2]
             # annotations := ((x1+x2)/2,(y1+y2)/2, rank(block.data))
-            [x1,x2,x2,x1,x1],[y1,y1,y2,y2,y1]
+            [x1, x2, x2, x1, x1], [y1, y1, y2, y2, y1]
         end
     end
 end

--- a/src/hyperrectangle.jl
+++ b/src/hyperrectangle.jl
@@ -34,7 +34,7 @@ half_width(r::HyperRectangle) = width(r) / 2
 Minimal Euclidean distance between a point `x ∈ Ω1` and `y ∈ Ω2`.
 """
 function distance(rec1::HyperRectangle{N},
-    rec2::HyperRectangle{N}) where {N}
+                  rec2::HyperRectangle{N}) where {N}
     d2 = 0
     rec1_low_corner = low_corner(rec1)
     rec1_high_corner = high_corner(rec1)
@@ -63,7 +63,6 @@ function distance(pt::SVector{N}, rec::HyperRectangle{N}) where {N}
 end
 distance(rec::HyperRectangle{N}, pt::SVector{N}) where {N} = distance(pt, rec)
 
-
 """
     diameter(Ω)
 
@@ -91,24 +90,24 @@ function vertices(rec::HyperRectangle{2})
     lc = low_corner(rec)
     hc = high_corner(rec)
     return SVector(SVector(lc[1], lc[2]),
-        SVector(hc[1], lc[2]),
-        SVector(hc[1], hc[2]),
-        SVector(lc[1], hc[2]))
+                   SVector(hc[1], lc[2]),
+                   SVector(hc[1], hc[2]),
+                   SVector(lc[1], hc[2]))
 end
 function vertices(rec::HyperRectangle{3})
     lc = low_corner(rec)
     hc = high_corner(rec)
     return SVector(
-        # lower face
-        SVector(lc[1], lc[2], lc[3]),
-        SVector(hc[1], lc[2], lc[3]),
-        SVector(hc[1], hc[2], lc[3]),
-        SVector(lc[1], hc[2], lc[3]),
-        # upper face
-        SVector(lc[1], lc[2], hc[3]),
-        SVector(hc[1], lc[2], hc[3]),
-        SVector(hc[1], hc[2], hc[3]),
-        SVector(lc[1], hc[2], hc[3]))
+                   # lower face
+                   SVector(lc[1], lc[2], lc[3]),
+                   SVector(hc[1], lc[2], lc[3]),
+                   SVector(hc[1], hc[2], lc[3]),
+                   SVector(lc[1], hc[2], lc[3]),
+                   # upper face
+                   SVector(lc[1], lc[2], hc[3]),
+                   SVector(hc[1], lc[2], hc[3]),
+                   SVector(hc[1], hc[2], hc[3]),
+                   SVector(lc[1], hc[2], hc[3]))
 end
 
 function bounding_box(els, cube=false)
@@ -133,7 +132,7 @@ function bounding_box(els, cube=false)
     return HyperRectangle(lb, ub)
 end
 center(x::SVector) = x
-center(x::NTuple)  = SVector(x)
+center(x::NTuple) = SVector(x)
 
 """
     split(rec::HyperRectangle,[axis]::Int,[place])
@@ -148,8 +147,8 @@ When no axis and no place is given, defaults to splitting along the largest axis
 function Base.split(rec::HyperRectangle{N}, axis, place) where {N}
     rec_low_corner = low_corner(rec)
     rec_high_corner = high_corner(rec)
-    high_corner1 = ntuple(n -> n == axis ? place : rec_high_corner[n], N) |> SVector
-    low_corner2  = ntuple(n -> n == axis ? place : rec_low_corner[n], N)  |> SVector
+    high_corner1 = SVector(ntuple(n -> n == axis ? place : rec_high_corner[n], N))
+    low_corner2 = SVector(ntuple(n -> n == axis ? place : rec_low_corner[n], N))
     rec1 = HyperRectangle(rec_low_corner, high_corner1)
     rec2 = HyperRectangle(low_corner2, rec_high_corner)
     return (rec1, rec2)

--- a/src/hyperrectangle.jl
+++ b/src/hyperrectangle.jl
@@ -1,0 +1,164 @@
+"""
+    struct HyperRectangle{N,T}
+
+Axis-aligned hyperrectangle in `N` dimensions given by `low_corner::SVector{N,T}` and
+`high_corner::SVector{N,T}`.
+"""
+struct HyperRectangle{N,T}
+    low_corner::SVector{N,T}
+    high_corner::SVector{N,T}
+end
+HyperRectangle(l::Tuple, h::Tuple) = HyperRectangle(SVector(l), SVector(h))
+HyperRectangle(l::SVector, h::SVector) = HyperRectangle(promote(l, h)...)
+# 1d case
+HyperRectangle(a::Number, b::Number) = HyperRectangle(SVector(a), SVector(b))
+
+# Base.eltype(::HyperRectangle{N,T}) where {N,T} = T
+# ambient_dimension(::HyperRectangle{N}) where {N} = N
+# geometric_dimension(::HyperRectangle{N}) where {N} = N
+low_corner(r::HyperRectangle) = r.low_corner
+high_corner(r::HyperRectangle) = r.high_corner
+
+function Base.isapprox(h1::HyperRectangle, h2::HyperRectangle; kwargs...)
+    return isapprox(h1.low_corner, h2.low_corner; kwargs...) &&
+           isapprox(h1.high_corner, h2.high_corner; kwargs...)
+end
+
+width(r::HyperRectangle) = high_corner(r) - low_corner(r)
+
+half_width(r::HyperRectangle) = width(r) / 2
+
+"""
+    distance(Ω1,Ω2)
+
+Minimal Euclidean distance between a point `x ∈ Ω1` and `y ∈ Ω2`.
+"""
+function distance(rec1::HyperRectangle{N},
+    rec2::HyperRectangle{N}) where {N}
+    d2 = 0
+    rec1_low_corner = low_corner(rec1)
+    rec1_high_corner = high_corner(rec1)
+    rec2_low_corner = low_corner(rec2)
+    rec2_high_corner = high_corner(rec2)
+    for i in 1:N
+        d2 += max(0, rec1_low_corner[i] - rec2_high_corner[i])^2 +
+              max(0, rec2_low_corner[i] - rec1_high_corner[i])^2
+    end
+    return sqrt(d2)
+end
+
+"""
+    distance(x::SVector,r::HyperRectangle)
+
+The (minimal) Euclidean distance between the point `x` and any point `y ∈ r`.
+"""
+function distance(pt::SVector{N}, rec::HyperRectangle{N}) where {N}
+    d2 = 0
+    rec_low_corner = low_corner(rec)
+    rec_high_corner = high_corner(rec)
+    for i in 1:N
+        d2 += max(0, pt[i] - rec_high_corner[i])^2 + max(0, rec_low_corner[i] - pt[i])^2
+    end
+    return sqrt(d2)
+end
+distance(rec::HyperRectangle{N}, pt::SVector{N}) where {N} = distance(pt, rec)
+
+
+"""
+    diameter(Ω)
+
+Largest distance between `x` and `y` for `x,y ∈ Ω`.
+"""
+diameter(r::HyperRectangle) = norm(high_corner(r) .- low_corner(r), 2)
+
+"""
+    radius(Ω)
+
+Half the [`diameter`](@ref).
+"""
+radius(r::HyperRectangle) = diameter(r) / 2
+
+"""
+    center(Ω)
+
+Center of the smallest ball containing `Ω`.
+"""
+center(r::HyperRectangle) = (low_corner(r) + high_corner(r)) / 2
+
+Base.in(point, h::HyperRectangle) = all(low_corner(h) .<= point .<= high_corner(h))
+
+function vertices(rec::HyperRectangle{2})
+    lc = low_corner(rec)
+    hc = high_corner(rec)
+    return SVector(SVector(lc[1], lc[2]),
+        SVector(hc[1], lc[2]),
+        SVector(hc[1], hc[2]),
+        SVector(lc[1], hc[2]))
+end
+function vertices(rec::HyperRectangle{3})
+    lc = low_corner(rec)
+    hc = high_corner(rec)
+    return SVector(
+        # lower face
+        SVector(lc[1], lc[2], lc[3]),
+        SVector(hc[1], lc[2], lc[3]),
+        SVector(hc[1], hc[2], lc[3]),
+        SVector(lc[1], hc[2], lc[3]),
+        # upper face
+        SVector(lc[1], lc[2], hc[3]),
+        SVector(hc[1], lc[2], hc[3]),
+        SVector(hc[1], hc[2], hc[3]),
+        SVector(lc[1], hc[2], hc[3]))
+end
+
+function bounding_box(els, cube=false)
+    isempty(els) && (error("data cannot be empty"))
+    lb = center(first(els))
+    ub = center(first(els))
+    for el in els
+        pt = center(el)
+        lb = min.(lb, pt)
+        ub = max.(ub, pt)
+    end
+    if cube # fit a square/cube instead
+        w = maximum(ub - lb)
+        xc = (ub + lb) / 2
+        # min/max below helps avoid floating point issues with results with the
+        # cube not being exactly contained in the original rectangle
+        lb = min.(xc .- w / 2, lb)
+        ub = max.(xc .+ w / 2, ub)
+        # TODO: return HyperCube instead
+    end
+    lb == ub && (lb = prevfloat.(lb); ub = nextfloat.(ub)) # to avoid "empty" rectangles
+    return HyperRectangle(lb, ub)
+end
+center(x::SVector) = x
+center(x::NTuple)  = SVector(x)
+
+"""
+    split(rec::HyperRectangle,[axis]::Int,[place])
+
+Split a hyperrectangle in two along the `axis` direction at the  position
+`place`. Returns a tuple with the two resulting hyperrectangles.
+
+When no `place` is given, defaults to splitting in the middle of the axis.
+
+When no axis and no place is given, defaults to splitting along the largest axis.
+"""
+function Base.split(rec::HyperRectangle{N}, axis, place) where {N}
+    rec_low_corner = low_corner(rec)
+    rec_high_corner = high_corner(rec)
+    high_corner1 = ntuple(n -> n == axis ? place : rec_high_corner[n], N) |> SVector
+    low_corner2  = ntuple(n -> n == axis ? place : rec_low_corner[n], N)  |> SVector
+    rec1 = HyperRectangle(rec_low_corner, high_corner1)
+    rec2 = HyperRectangle(low_corner2, rec_high_corner)
+    return (rec1, rec2)
+end
+function Base.split(rec::HyperRectangle, axis)
+    place = (high_corner(rec)[axis] + low_corner(rec)[axis]) / 2
+    return split(rec, axis, place)
+end
+function Base.split(rec::HyperRectangle)
+    axis = argmax(high_corner(rec) .- low_corner(rec))
+    return split(rec, axis)
+end

--- a/src/kernelmatrix.jl
+++ b/src/kernelmatrix.jl
@@ -36,14 +36,14 @@ struct KernelMatrix{Tf,Tx,Ty,T} <: AbstractKernelMatrix{T}
     Y::Ty
 end
 
-Base.size(K::KernelMatrix)                   = length(K.X), length(K.Y)
-Base.getindex(K::KernelMatrix,i::Int,j::Int) =  K.f(K.X[i],K.Y[j])
+Base.size(K::KernelMatrix) = length(K.X), length(K.Y)
+Base.getindex(K::KernelMatrix, i::Int, j::Int) = K.f(K.X[i], K.Y[j])
 
 rowelements(K::KernelMatrix) = K.X
 colelements(K::KernelMatrix) = K.Y
 kernel(K::KernelMatrix) = K.f
 
-function KernelMatrix(f,X,Y)
-    T = Base.promote_op(f,eltype(X),eltype(Y))
-    KernelMatrix{typeof(f),typeof(X),typeof(Y),T}(f,X,Y)
+function KernelMatrix(f, X, Y)
+    T = Base.promote_op(f, eltype(X), eltype(Y))
+    return KernelMatrix{typeof(f),typeof(X),typeof(Y),T}(f, X, Y)
 end

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -24,7 +24,7 @@ function mul!(C::HMatrix,A::HMatrix,B::HMatrix,a::Number,b::Number)
 end
 
 """
-    struct HMulNode{S,T} <: AbstractTree
+    struct HMulNode{S,T}
 
 Tree data structure representing the following computation:
 ```
@@ -37,7 +37,7 @@ This structure is used to group the operations required when multiplying
 hierarchical matrices so that they can later be executed in a way that minimizes
 recompression of intermediate computations.
 """
-mutable struct HMulNode{T} <: AbstractTree
+mutable struct HMulNode{T}
     target::T
     children::Matrix{HMulNode{T}}
     sources::Vector{Tuple{T,T}}

--- a/src/rkmatrix.jl
+++ b/src/rkmatrix.jl
@@ -11,29 +11,29 @@ mutable struct RkMatrix{T} <: AbstractMatrix{T}
     A::Matrix{T}
     B::Matrix{T}
     buffer::Vector{T} # used for gemv routines to avoid allocations
-    function RkMatrix(A::Matrix{T},B::Matrix{T}) where {T}
-        @assert size(A,2) == size(B,2) "second dimension of `A` and `B` must match"
-        m,r = size(A)
-        n  = size(B,1)
-        if  r*(m+n) >= m*n
+    function RkMatrix(A::Matrix{T}, B::Matrix{T}) where {T}
+        @assert size(A, 2) == size(B, 2) "second dimension of `A` and `B` must match"
+        m, r = size(A)
+        n = size(B, 1)
+        if r * (m + n) >= m * n
             @debug "Inefficient RkMatrix:" size(A) size(B)
             # error("Inefficient RkMatrix")
         end
-        buffer = Vector{T}(undef,r)
-        new{T}(A,B,buffer)
+        buffer = Vector{T}(undef, r)
+        return new{T}(A, B, buffer)
     end
 end
-RkMatrix(A,B) = RkMatrix(promote(A,B)...)
+RkMatrix(A, B) = RkMatrix(promote(A, B)...)
 
-function Base.setproperty!(R::RkMatrix,s::Symbol,mat::Matrix)
-    setfield!(R,s,mat)
+function Base.setproperty!(R::RkMatrix, s::Symbol, mat::Matrix)
+    setfield!(R, s, mat)
     # resize buffer
-    r = size(mat,2)
-    resize!(R.buffer,r)
+    r = size(mat, 2)
+    resize!(R.buffer, r)
     return R
 end
 
-function Base.getindex(rmat::RkMatrix,i::Int,j::Int)
+function Base.getindex(rmat::RkMatrix, i::Int, j::Int)
     msg = """
     method `getindex(::AbstractHMatrix,args...)` has been disabled to avoid
     performance pitfalls. Unless you made an explicit call to `getindex`, this
@@ -44,7 +44,7 @@ function Base.getindex(rmat::RkMatrix,i::Int,j::Int)
         r = rank(rmat)
         acc = zero(eltype(rmat))
         for k in 1:r
-            acc += rmat.A[i,k] * conj(rmat.B[j,k])
+            acc += rmat.A[i, k] * conj(rmat.B[j, k])
         end
     else
         error(msg)
@@ -53,15 +53,15 @@ function Base.getindex(rmat::RkMatrix,i::Int,j::Int)
 end
 
 # some "fast" ways of computing a column of R and row of ajoint(R)
-Base.getindex(R::RkMatrix, ::Colon, j::Int) = getcol(R,j)
+Base.getindex(R::RkMatrix, ::Colon, j::Int) = getcol(R, j)
 
 """
     getcol!(col,M::AbstractMatrix,j)
 
 Fill the entries of `col` with column `j` of `M`.
 """
-function getcol!(col,R::RkMatrix,j::Int)
-    mul!(col,R.A,conj(view(R.B,j,:)))
+function getcol!(col, R::RkMatrix, j::Int)
+    return mul!(col, R.A, conj(view(R.B, j, :)))
 end
 
 """
@@ -69,26 +69,26 @@ end
 
 Return a vector containing the `j`-th column of `M`.
 """
-function getcol(R::RkMatrix,j::Int)
-    m = size(R,1)
+function getcol(R::RkMatrix, j::Int)
+    m = size(R, 1)
     T = eltype(R)
-    col = zeros(T,m)
-    getcol!(col,R,j)
+    col = zeros(T, m)
+    return getcol!(col, R, j)
 end
 
-function getcol!(col,Ra::Adjoint{<:Any,<:RkMatrix},j::Int)
+function getcol!(col, Ra::Adjoint{<:Any,<:RkMatrix}, j::Int)
     R = parent(Ra)
-    mul!(col,R.B,conj(view(R.A,j,:)))
+    return mul!(col, R.B, conj(view(R.A, j, :)))
 end
 
-function getcol(Ra::Adjoint{<:Any,<:RkMatrix},j::Int)
-    m = size(Ra,1)
+function getcol(Ra::Adjoint{<:Any,<:RkMatrix}, j::Int)
+    m = size(Ra, 1)
     T = eltype(Ra)
-    col = zeros(T,m)
-    getcol!(col,Ra,j)
+    col = zeros(T, m)
+    return getcol!(col, Ra, j)
 end
 
-Base.getindex(Ra::Adjoint{<:Any,<:RkMatrix}, ::Colon, j::Int) = getcol(Ra,j)
+Base.getindex(Ra::Adjoint{<:Any,<:RkMatrix}, ::Colon, j::Int) = getcol(Ra, j)
 
 """
     RkMatrix(A::Vector{<:Vector},B::Vector{<:Vector})
@@ -97,35 +97,37 @@ Construct an `RkMatrix` from a vector of vectors. Assumes that `length(A) ==
 length(B)`, which determines the rank, and that all vectors in `A` (resp. `B`) have the same length `m`
 (resp. `n`).
 """
-function RkMatrix(_A::Vector{V},_B::Vector{V}) where {V<:AbstractVector}
-    T   = eltype(V)
+function RkMatrix(_A::Vector{V}, _B::Vector{V}) where {V<:AbstractVector}
+    T = eltype(V)
     @assert length(_A) == length(_B)
-    k   = length(_A)
-    m   = length(first(_A))
-    n   = length(first(_B))
-    A   = Matrix{T}(undef,m,k)
-    B  = Matrix{T}(undef,n,k)
+    k = length(_A)
+    m = length(first(_A))
+    n = length(first(_B))
+    A = Matrix{T}(undef, m, k)
+    B = Matrix{T}(undef, n, k)
     for i in 1:k
-        copyto!(view(A,:,i),_A[i])
-        copyto!(view(B,:,i),_B[i])
+        copyto!(view(A, :, i), _A[i])
+        copyto!(view(B, :, i), _B[i])
     end
-    return RkMatrix(A,B)
+    return RkMatrix(A, B)
 end
 
 Base.eltype(::RkMatrix{T}) where {T} = T
-Base.size(rmat::RkMatrix)                                        = (size(rmat.A,1), size(rmat.B,1))
-Base.length(rmat::RkMatrix)                                      = prod(size(rmat))
-Base.isapprox(rmat::RkMatrix,B::AbstractArray,args...;kwargs...) = isapprox(Matrix(rmat),B,args...;kwargs...)
+Base.size(rmat::RkMatrix) = (size(rmat.A, 1), size(rmat.B, 1))
+Base.length(rmat::RkMatrix) = prod(size(rmat))
+function Base.isapprox(rmat::RkMatrix, B::AbstractArray, args...; kwargs...)
+    return isapprox(Matrix(rmat), B, args...; kwargs...)
+end
 
-rank(M::RkMatrix) = size(M.A,2)
+rank(M::RkMatrix) = size(M.A, 2)
 
-function Base.getproperty(R::RkMatrix,s::Symbol)
-    if  s == :Bt
+function Base.getproperty(R::RkMatrix, s::Symbol)
+    if s == :Bt
         return adjoint(R.B)
-    elseif  s == :At
+    elseif s == :At
         return adjoint(R.A)
     else
-        return getfield(R,s)
+        return getfield(R, s)
     end
 end
 
@@ -135,17 +137,18 @@ end
 Concatenated `M1` and `M2` horizontally to produce a new `RkMatrix` of rank
 `rank(M1)+rank(M2)`.
 """
-function Base.hcat(M1::RkMatrix{T},M2::RkMatrix{T}) where {T}
-    m,n  = size(M1)
-    s,t  = size(M2)
-    (m == s) || throw(ArgumentError("number of rows of each array must match: got  ($m,$s)"))
-    r1   = size(M1.A,2)
-    r2   = size(M2.A,2)
-    A    = hcat(M1.A,M2.A)
-    B1   = vcat(M1.B,zeros(T,t,r1))
-    B2   = vcat(zeros(T,n,r2),M2.B)
-    B    = hcat(B1,B2)
-    return RkMatrix(A,B)
+function Base.hcat(M1::RkMatrix{T}, M2::RkMatrix{T}) where {T}
+    m, n = size(M1)
+    s, t = size(M2)
+    (m == s) ||
+        throw(ArgumentError("number of rows of each array must match: got  ($m,$s)"))
+    r1 = size(M1.A, 2)
+    r2 = size(M2.A, 2)
+    A = hcat(M1.A, M2.A)
+    B1 = vcat(M1.B, zeros(T, t, r1))
+    B2 = vcat(zeros(T, n, r2), M2.B)
+    B = hcat(B1, B2)
+    return RkMatrix(A, B)
 end
 
 """
@@ -154,28 +157,29 @@ end
 Concatenated `M1` and `M2` vertically to produce a new `RkMatrix` of rank
 `rank(M1)+rank(M2)`
 """
-function Base.vcat(M1::RkMatrix{T},M2::RkMatrix{T}) where {T}
-    m,n  = size(M1)
-    s,t  = size(M2)
-    n == t || throw(ArgumentError("number of columns of each array must match (got  ($n,$t))"))
-    r1   = size(M1.A,2)
-    r2   = size(M2.A,2)
-    A1   = vcat(M1.A,zeros(T,s,r1))
-    A2   = vcat(zeros(T,m,r2),M2.A)
-    A    = hcat(A1,A2)
-    B    = hcat(M1.B,M2.B)
-    return RkMatrix(A,B)
+function Base.vcat(M1::RkMatrix{T}, M2::RkMatrix{T}) where {T}
+    m, n = size(M1)
+    s, t = size(M2)
+    n == t ||
+        throw(ArgumentError("number of columns of each array must match (got  ($n,$t))"))
+    r1 = size(M1.A, 2)
+    r2 = size(M2.A, 2)
+    A1 = vcat(M1.A, zeros(T, s, r1))
+    A2 = vcat(zeros(T, m, r2), M2.A)
+    A = hcat(A1, A2)
+    B = hcat(M1.B, M2.B)
+    return RkMatrix(A, B)
 end
 
-Base.copy(R::RkMatrix) = RkMatrix(copy(R.A),copy(R.B))
+Base.copy(R::RkMatrix) = RkMatrix(copy(R.A), copy(R.B))
 
 function Base.Matrix(R::RkMatrix{<:Number})
-    Matrix(R.A*R.Bt)
+    return Matrix(R.A * R.Bt)
 end
 function Base.Matrix(R::RkMatrix{<:SMatrix})
     # collect must be used when we have a matrix of `SMatrix` because of this issue:
     # https://github.com/JuliaArrays/StaticArrays.jl/issues/966#issuecomment-943679214
-    R.A*collect(R.Bt)
+    return R.A * collect(R.Bt)
 end
 
 """
@@ -184,9 +188,9 @@ end
 Construct an [`RkMatrix`](@ref) from an `SVD` factorization.
 """
 function RkMatrix(F::SVD)
-    A  = F.U*Diagonal(F.S)
-    B  = copy(F.V)
-    return RkMatrix(A,B)
+    A = F.U * Diagonal(F.S)
+    B = copy(F.V)
+    return RkMatrix(A, B)
 end
 
 """
@@ -197,7 +201,7 @@ Construct an [`RkMatrix`](@ref) from a `Matrix` by passing through the full
 """
 function RkMatrix(M::Matrix)
     F = svd(M)
-    RkMatrix(F)
+    return RkMatrix(F)
 end
 
 """
@@ -206,7 +210,7 @@ end
 The number of entries stored in the representation. Note that this is *not*
 `length(R)`.
 """
-num_stored_elements(R::RkMatrix)        = size(R.A,2)*(sum(size(R)))
+num_stored_elements(R::RkMatrix) = size(R.A, 2) * (sum(size(R)))
 
 """
     compression_ratio(R::RkMatrix)
@@ -222,15 +226,16 @@ compression_ratio(R::RkMatrix) = prod(size(R)) / num_stored_elements(R)
 # problem in LinearAlgebra for the generic mulplication mul!(C,A,B,a,b) when
 # C and B are a vectors of static matrices, and A is a matrix of static
 # matrices. Should eventually be removed.
-function mul!(C::AbstractVector,Rk::RkMatrix{T},F::AbstractVector,a::Number,b::Number) where {T<:SMatrix}
-    m,n = size(Rk)
-    r   = rank(Rk)
-    tmp = Rk.Bt*F
-    rmul!(C,b)
+function mul!(C::AbstractVector, Rk::RkMatrix{T}, F::AbstractVector, a::Number,
+              b::Number) where {T<:SMatrix}
+    m, n = size(Rk)
+    r = rank(Rk)
+    tmp = Rk.Bt * F
+    rmul!(C, b)
     for k in 1:r
         tmp[k] *= a
         for i in 1:m
-            C[i] += Rk.A[i,k]*tmp[k]
+            C[i] += Rk.A[i, k] * tmp[k]
         end
     end
     return C

--- a/src/splitter.jl
+++ b/src/splitter.jl
@@ -134,7 +134,7 @@ the "left" node) or `false` (point sorted on the "right" node). At the end a
 minimal `HyperRectangle` containing all left/right points is created.
 """
 function binary_split!(cluster::ClusterTree{N,T}, predicate::Function) where {N,T}
-    f   = predicate
+    f = predicate
     rec = container(cluster)
     els = root_elements(cluster)
     irange = index_range(cluster)
@@ -156,12 +156,12 @@ function binary_split!(cluster::ClusterTree{N,T}, predicate::Function) where {N,
         else
             xl_right = min.(xl_right, pt)
             xu_right = max.(xu_right, pt)
-            buff[n-npts_right] = l2g[i]
+            buff[n - npts_right] = l2g[i]
             npts_right += 1
         end
     end
     # bounding boxes
-    left_rec  = HyperRectangle(xl_left, xu_left)
+    left_rec = HyperRectangle(xl_left, xu_left)
     right_rec = HyperRectangle(xl_right, xu_right)
     @assert npts_left + npts_right == length(irange) "elements lost during split"
     # new ranges for children cluster

--- a/src/splitter.jl
+++ b/src/splitter.jl
@@ -1,0 +1,175 @@
+"""
+    abstract type AbstractSplitter
+
+An `AbstractSplitter` is used to split a [`ClusterTree`](@ref). The interface
+requires the following methods:
+- `should_split(clt,splitter)` : return a `Bool` determining if the
+  `ClusterTree` should be further divided
+- `split!(clt,splitter)` : perform the splitting of the `ClusterTree` handling
+  the necessary data sorting.
+
+See [`GeometricSplitter`](@ref) for an example of an implementation.
+"""
+abstract type AbstractSplitter end
+
+"""
+    should_split(clt::ClusterTree, depth, splitter::AbstractSplitter)
+
+Determine whether or not a `ClusterTree` should be further divided.
+"""
+function should_split end
+
+"""
+    split!(clt::ClusterTree,splitter::AbstractSplitter)
+
+Divide `clt` using the strategy implemented by `splitter`. This function is
+reponsible of assigning the `children` and `parent` fields, as well as of
+permuting the data of `clt`.
+"""
+function split! end
+
+"""
+    struct GeometricSplitter <: AbstractSplitter
+
+Used to split a `ClusterTree` in half along the largest axis. The children boxes
+are shrank to tighly fit the data.
+"""
+Base.@kwdef struct GeometricSplitter <: AbstractSplitter
+    nmax::Int = 50
+end
+
+function should_split(node::ClusterTree, depth, splitter::GeometricSplitter)
+    return length(node) > splitter.nmax
+end
+
+function split!(cluster::ClusterTree, ::GeometricSplitter)
+    rec = cluster.container
+    wmax, imax = findmax(high_corner(rec) - low_corner(rec))
+    mid = low_corner(rec)[imax] + wmax / 2
+    predicate = (x) -> x[imax] < mid
+    left_node, right_node = binary_split!(cluster, predicate)
+    cluster.children = [left_node, right_node]
+    return cluster
+end
+
+"""
+    struct PrincipalComponentSplitter <: AbstractSplitter
+"""
+Base.@kwdef struct PrincipalComponentSplitter <: AbstractSplitter
+    nmax::Int = 50
+end
+
+function should_split(node::ClusterTree, depth, splitter::PrincipalComponentSplitter)
+    return length(node) > splitter.nmax
+end
+
+function split!(cluster::ClusterTree, ::PrincipalComponentSplitter)
+    pts = cluster._elements
+    irange = cluster.index_range
+    xc = center_of_mass(cluster)
+    # compute covariance matrix for principal direction
+    l2g = loc2glob(cluster)
+    cov = sum(irange) do i
+        x = center(pts[l2g[i]])
+        return (x - xc) * transpose(x - xc)
+    end
+    v = eigvecs(cov)[:, end]
+    predicate = (x) -> dot(x - xc, v) < 0
+    left_node, right_node = binary_split!(cluster, predicate)
+    cluster.children = [left_node, right_node]
+    return cluster
+end
+
+function center_of_mass(clt::ClusterTree)
+    pts = clt._elements
+    loc_idxs = clt.index_range
+    l2g = loc2glob(clt)
+    # w    = clt.weights
+    n = length(loc_idxs)
+    # M    = isempty(w) ? n : sum(i->w[i],glob_idxs)
+    # xc   = isempty(w) ? sum(i->pts[i]/M,glob_idxs) : sum(i->w[i]*pts[i]/M,glob_idxs)
+    M = n
+    xc = sum(i -> center(pts[l2g[i]]) / M, loc_idxs)
+    return xc
+end
+
+"""
+    struct CardinalitySplitter <: AbstractSplitter
+
+Used to split a `ClusterTree` along the largest dimension if
+`length(tree)>nmax`. The split is performed so the `data` is evenly distributed
+amongst all children.
+
+## See also: [`AbstractSplitter`](@ref)
+"""
+Base.@kwdef struct CardinalitySplitter <: AbstractSplitter
+    nmax::Int = 50
+end
+
+function should_split(node::ClusterTree, depth, splitter::CardinalitySplitter)
+    return length(node) > splitter.nmax
+end
+
+function split!(cluster::ClusterTree, ::CardinalitySplitter)
+    points = cluster._elements
+    irange = cluster.index_range
+    rec = container(cluster)
+    _, imax = findmax(high_corner(rec) - low_corner(rec))
+    l2g = loc2glob(cluster)
+    med = median(center(points[l2g[i]])[imax] for i in irange) # the median along largest axis `imax`
+    predicate = (x) -> x[imax] < med
+    left_node, right_node = binary_split!(cluster, predicate)
+    cluster.children = [left_node, right_node]
+    return cluster
+end
+
+"""
+    binary_split!(cluster::ClusterTree,predicate)
+
+Split a `ClusterTree` into two, sorting all elements in the process according to
+predicate. `cluster` is assigned as parent to each children.
+
+Each point is sorted according to whether `f(x)` returns `true` (point sorted on
+the "left" node) or `false` (point sorted on the "right" node). At the end a
+minimal `HyperRectangle` containing all left/right points is created.
+"""
+function binary_split!(cluster::ClusterTree{N,T}, predicate::Function) where {N,T}
+    f   = predicate
+    rec = container(cluster)
+    els = root_elements(cluster)
+    irange = index_range(cluster)
+    n = length(irange)
+    buff = view(cluster.buffer, irange)
+    l2g = loc2glob(cluster)
+    npts_left = 0
+    npts_right = 0
+    xl_left = xl_right = high_corner(rec)
+    xu_left = xu_right = low_corner(rec)
+    # sort the points into left and right rectangle
+    for i in irange
+        pt = els[l2g[i]]
+        if f(pt)
+            xl_left = min.(xl_left, pt)
+            xu_left = max.(xu_left, pt)
+            npts_left += 1
+            buff[npts_left] = l2g[i]
+        else
+            xl_right = min.(xl_right, pt)
+            xu_right = max.(xu_right, pt)
+            buff[n-npts_right] = l2g[i]
+            npts_right += 1
+        end
+    end
+    # bounding boxes
+    left_rec  = HyperRectangle(xl_left, xu_left)
+    right_rec = HyperRectangle(xl_right, xu_right)
+    @assert npts_left + npts_right == length(irange) "elements lost during split"
+    # new ranges for children cluster
+    copy!(view(l2g, irange), buff)
+    left_indices = (irange.start):((irange.start) + npts_left - 1)
+    right_indices = (irange.start + npts_left):(irange.stop)
+    # create children
+    clt1 = ClusterTree(els, left_rec, left_indices, l2g, cluster.buffer, nothing, cluster)
+    clt2 = ClusterTree(els, right_rec, right_indices, l2g, cluster.buffer, nothing, cluster)
+    return clt1, clt2
+end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1,5 +1,5 @@
 const HUnitLowerTriangular = UnitLowerTriangular{<:Any,<:HMatrix}
-const HUpperTriangular     = UpperTriangular{<:Any,<:HMatrix}
+const HUpperTriangular = UpperTriangular{<:Any,<:HMatrix}
 
 function ldiv!(L::HUnitLowerTriangular, B::AbstractMatrix)
     H = parent(L)
@@ -9,19 +9,19 @@ function ldiv!(L::HUnitLowerTriangular, B::AbstractMatrix)
     else
         @assert !hasdata(H) "only leaves are allowed to have data when using `ldiv`!"
         shift = pivot(H) .- 1
-        chdH  = children(H)
-        m, n   = size(chdH)
+        chdH = children(H)
+        m, n = size(chdH)
         @assert m === n
-        for i = 1:m
-            irows  = colrange(chdH[i,i]) .- shift[2]
-            bi     = view(B, irows, :)
-            for j = 1:(i - 1)# j<i
-                jrows  = colrange(chdH[i,j]) .- shift[2]
-                bj     = view(B, jrows, :)
-                _mul131!(bi, chdH[i,j], bj, -1)
+        for i in 1:m
+            irows = colrange(chdH[i, i]) .- shift[2]
+            bi = view(B, irows, :)
+            for j in 1:(i - 1)# j<i
+                jrows = colrange(chdH[i, j]) .- shift[2]
+                bj = view(B, jrows, :)
+                _mul131!(bi, chdH[i, j], bj, -1)
             end
             # recursion stage
-            ldiv!(UnitLowerTriangular(chdH[i,i]), bi)
+            ldiv!(UnitLowerTriangular(chdH[i, i]), bi)
         end
     end
     return B
@@ -43,16 +43,16 @@ function ldiv!(L::HUnitLowerTriangular, X::HMatrix, compressor)
     else
         chdH = children(H)
         chdX = children(X)
-        m, n  = size(chdH)
+        m, n = size(chdH)
         @assert m == n
         for k in 1:size(chdX, 2)
-            for i = 1:m
-                for j = 1:(i - 1)# j<i
+            for i in 1:m
+                for j in 1:(i - 1)# j<i
                     @timeit_debug "hmul!" begin
-                        hmul!(chdX[i,k], chdH[i,j], chdX[j,k], -1, 1, compressor)
+                        hmul!(chdX[i, k], chdH[i, j], chdX[j, k], -1, 1, compressor)
                     end
                 end
-                ldiv!(UnitLowerTriangular(chdH[i,i]), chdX[i,k], compressor)
+                ldiv!(UnitLowerTriangular(chdH[i, i]), chdX[i, k], compressor)
             end
         end
     end
@@ -67,19 +67,19 @@ function ldiv!(U::HUpperTriangular, B::AbstractMatrix)
     else
         @assert !hasdata(H) "only leaves are allowed to have data when using `ldiv`!"
         shift = pivot(H) .- 1
-        chdH  = children(H)
-        m, n   = size(chdH)
+        chdH = children(H)
+        m, n = size(chdH)
         @assert m === n
-        for i = m:-1:1
-            irows  = colrange(chdH[i,i]) .- shift[2]
-            bi     = view(B, irows, :)
-            for j = i+1:n # j>i
-                jrows  = colrange(chdH[i,j]) .- shift[2]
-                bj     = view(B, jrows, :)
-                _mul131!(bi, chdH[i,j], bj, -1)
+        for i in m:-1:1
+            irows = colrange(chdH[i, i]) .- shift[2]
+            bi = view(B, irows, :)
+            for j in (i + 1):n # j>i
+                jrows = colrange(chdH[i, j]) .- shift[2]
+                bj = view(B, jrows, :)
+                _mul131!(bi, chdH[i, j], bj, -1)
             end
             # recursion stage
-            ldiv!(UpperTriangular(chdH[i,i]), bi)
+            ldiv!(UpperTriangular(chdH[i, i]), bi)
         end
     end
     return B
@@ -93,20 +93,20 @@ function rdiv!(B::StridedMatrix, U::HUpperTriangular)
         rdiv!(B, UpperTriangular(d)) # b <-- b/L
     else
         @assert !hasdata(H) "only leaves are allowed to have data when using `rdiv`!"
-        shift = pivot(H) .- 1 |> reverse
-        chdH  = children(H)
-        m, n   = size(chdH)
+        shift = reverse(pivot(H) .- 1)
+        chdH = children(H)
+        m, n = size(chdH)
         @assert m === n
-        for i = 1:m
-            icols  = rowrange(chdH[i,i]) .- shift[1]
-            bi     = view(B, :, icols)
-            for j = 1:(i - 1)
-                jcols  = rowrange(chdH[j,i]) .- shift[1]
-                bj     = view(B, :, jcols)
-                _mul113!(bi, bj, chdH[j,i], -1)
+        for i in 1:m
+            icols = rowrange(chdH[i, i]) .- shift[1]
+            bi = view(B, :, icols)
+            for j in 1:(i - 1)
+                jcols = rowrange(chdH[j, i]) .- shift[1]
+                bj = view(B, :, jcols)
+                _mul113!(bi, bj, chdH[j, i], -1)
             end
             # recursion stage
-            rdiv!(bi, UpperTriangular(chdH[i,i]))
+            rdiv!(bi, UpperTriangular(chdH[i, i]))
         end
     end
     return B
@@ -135,13 +135,13 @@ function rdiv!(X::AbstractHMatrix, U::HUpperTriangular, compressor)
         chdH = children(H)
         m, n = size(chdH)
         for k in 1:size(chdX, 1)
-            for i = 1:m
-                for j = 1:(i - 1)
+            for i in 1:m
+                for j in 1:(i - 1)
                     @timeit_debug "hmul!" begin
-                        hmul!(chdX[k,i], chdX[k,j], chdH[j,i], -1, 1, compressor)
+                        hmul!(chdX[k, i], chdX[k, j], chdH[j, i], -1, 1, compressor)
                     end
                 end
-                rdiv!(chdX[k,i], UpperTriangular(chdH[i,i]), compressor)
+                rdiv!(chdX[k, i], UpperTriangular(chdH[i, i]), compressor)
             end
         end
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,18 +30,18 @@ struct PermutedMatrix{K,T} <: AbstractMatrix{T}
     data::K # original matrix
     rowperm::Vector{Int}
     colperm::Vector{Int}
-    function PermutedMatrix(orig,rowperm,colperm)
+    function PermutedMatrix(orig, rowperm, colperm)
         K = typeof(orig)
         T = eltype(orig)
-        new{K,T}(orig,rowperm,colperm)
+        return new{K,T}(orig, rowperm, colperm)
     end
 end
 Base.size(M::PermutedMatrix) = size(M.data)
 
-function Base.getindex(M::PermutedMatrix,i,j)
+function Base.getindex(M::PermutedMatrix, i, j)
     ip = M.rowperm[i]
     jp = M.colperm[j]
-    M.data[ip,jp]
+    return M.data[ip, jp]
 end
 
 """
@@ -53,20 +53,20 @@ output `d` ranges from `0` to `n^2-1`.
 
 See [https://en.wikipedia.org/wiki/Hilbert_curve](https://en.wikipedia.org/wiki/Hilbert_curve).
 """
-function hilbert_cartesian_to_linear(n::Integer,x,y)
+function hilbert_cartesian_to_linear(n::Integer, x, y)
     @assert ispow2(n)
-    @assert 0 ≤ x ≤ n-1
-    @assert 0 ≤ y ≤ n-1
+    @assert 0 ≤ x ≤ n - 1
+    @assert 0 ≤ y ≤ n - 1
     d = 0
     s = n >> 1
-    while s>0
+    while s > 0
         rx = (x & s) > 0
         ry = (y & s) > 0
-        d += s^2*((3*rx)⊻ry)
-        x,y = _rot(n,x,y,rx,ry)
+        d += s^2 * ((3 * rx) ⊻ ry)
+        x, y = _rot(n, x, y, rx, ry)
         s = s >> 1
     end
-    @assert 0 ≤ d ≤ n^2-1
+    @assert 0 ≤ d ≤ n^2 - 1
     return d
 end
 
@@ -78,47 +78,47 @@ n-1` and `0 ≤ y ≤ n-1` on the Hilbert curve of order `n`.
 
 See [https://en.wikipedia.org/wiki/Hilbert_curve](https://en.wikipedia.org/wiki/Hilbert_curve).
 """
-function hilbert_linear_to_cartesian(n::Integer,d)
+function hilbert_linear_to_cartesian(n::Integer, d)
     @assert ispow2(n)
-    @assert 0 ≤ d ≤ n^2-1
-    x,y = 0,0
+    @assert 0 ≤ d ≤ n^2 - 1
+    x, y = 0, 0
     s = 1
-    while s<n
+    while s < n
         rx = 1 & (d >> 1)
         ry = 1 & (d ⊻ rx)
-        x,y = _rot(s,x,y,rx,ry)
-        x +=  s*rx
-        y +=  s*ry
+        x, y = _rot(s, x, y, rx, ry)
+        x += s * rx
+        y += s * ry
         d = d >> 2
         s = s << 1
     end
-    @assert 0 ≤ x ≤ n-1
-    @assert 0 ≤ y ≤ n-1
-    return x,y
+    @assert 0 ≤ x ≤ n - 1
+    @assert 0 ≤ y ≤ n - 1
+    return x, y
 end
 
 # auxiliary function using in hilbert curve. Rotates the points x,y
-function _rot(n,x,y,rx,ry)
+function _rot(n, x, y, rx, ry)
     if ry == 0
         if rx == 1
-            x = n-1 - x
-            y = n-1 - y
+            x = n - 1 - x
+            y = n - 1 - y
         end
-        x,y = y,x
+        x, y = y, x
     end
-    return x,y
+    return x, y
 end
 
 function hilbert_points(n::Integer)
     @assert ispow2(n)
     xx = Int[]
     yy = Int[]
-    for d in 0:n^2-1
-        x,y = hilbert_linear_to_cartesian(n,d)
-        push!(xx,x)
-        push!(yy,y)
+    for d in 0:(n^2 - 1)
+        x, y = hilbert_linear_to_cartesian(n, d)
+        push!(xx, x)
+        push!(yy, y)
     end
-    xx,yy
+    return xx, yy
 end
 
 """
@@ -136,7 +136,7 @@ disable_getindex() = (ALLOW_GETINDEX[] = false)
 
 The opposite of [`disable_getindex`](@ref).
 """
-enable_getindex()  = (ALLOW_GETINDEX[] = true)
+enable_getindex() = (ALLOW_GETINDEX[] = true)
 
 """
     filter_tree(f,tree,isterminal=true)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -137,3 +137,73 @@ disable_getindex() = (ALLOW_GETINDEX[] = false)
 The opposite of [`disable_getindex`](@ref).
 """
 enable_getindex()  = (ALLOW_GETINDEX[] = true)
+
+"""
+    filter_tree(f,tree,isterminal=true)
+
+Return a vector containing all the nodes of `tree` such that
+`f(node)==true`.  The argument `isterminal` can be used to control whether
+to continue the search on `children` of nodes for which `f(node)==true`.
+"""
+function filter_tree(f, tree, isterminal=true)
+    nodes = Vector{typeof(tree)}()
+    return filter_tree!(f, nodes, tree, isterminal)
+end
+
+"""
+    filter_tree!(filter,nodes,tree,[isterminal=true])
+
+Like [`filter_tree`](@ref), but appends results to `nodes`.
+"""
+function filter_tree!(f, nodes, tree, isterminal=true)
+    if f(tree)
+        push!(nodes, tree)
+        # terminate the search along this path if terminal=true
+        isterminal || map(x -> filter_tree!(f, nodes, x, isterminal), children(tree))
+    else
+        # continue on on children
+        map(x -> filter_tree!(f, nodes, x, isterminal), children(tree))
+    end
+    return nodes
+end
+
+"""
+    depth(tree,acc=0)
+
+Recursive function to compute the depth of `node` in a a tree-like structure.
+
+Overload this function if your structure has a more efficient way to compute
+`depth` (e.g. if it stores it in a field).
+"""
+function depth(tree, acc=0)
+    if isroot(tree)
+        return acc
+    else
+        depth(parent(tree), acc + 1)
+    end
+end
+
+"""
+    partition_by_depth(tree)
+
+Given a `tree`, return a `partition` vector whose `i`-th entry stores all the nodes in
+`tree` with `depth=i-1`. Empty nodes are not added to the partition.
+"""
+function partition_by_depth(tree)
+    T = typeof(tree)
+    partition = Vector{Vector{T}}()
+    depth = 0
+    return _partition_by_depth!(partition, tree, depth)
+end
+
+function _partition_by_depth!(partition, tree, depth)
+    T = typeof(tree)
+    if length(partition) < depth + 1
+        push!(partition, [])
+    end
+    length(tree) > 0 && push!(partition[depth + 1], tree)
+    for chd in children(tree)
+        _partition_by_depth!(partition, chd, depth + 1)
+    end
+    return partition
+end

--- a/test/addition_test.jl
+++ b/test/addition_test.jl
@@ -5,36 +5,36 @@ using Random
 using StaticArrays
 using HMatrices: RkMatrix
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
-N,r     = 500,3
-atol    = 1e-6
-X  = Y     = rand(SVector{3,Float64},N)
-splitter = CardinalitySplitter(nmax=50)
-Xclt = Yclt  = ClusterTree(X,splitter)
-adm       = StrongAdmissibilityStd(eta=3)
-rtol      = 1e-5
-comp      = PartialACA(rtol=rtol)
-K         = helmholtz_matrix(X,Y,1.3)
-H         = assemble_hmat(K,Xclt,Yclt;adm,comp,threads=false,distributed=false)
-T         = eltype(H)
-_H   = Matrix(H;global_index=false)
-R    = RkMatrix(rand(T,N,r),rand(T,N,r))
-_R   = Matrix(R)
-M    = rand(T,N,N)
-_M   = Matrix(M)
-a    = rand()
+N, r = 500, 3
+atol = 1e-6
+X = Y = rand(SVector{3,Float64}, N)
+splitter = CardinalitySplitter(; nmax=50)
+Xclt = Yclt = ClusterTree(X, splitter)
+adm = StrongAdmissibilityStd(; eta=3)
+rtol = 1e-5
+comp = PartialACA(; rtol=rtol)
+K = helmholtz_matrix(X, Y, 1.3)
+H = assemble_hmat(K, Xclt, Yclt; adm, comp, threads=false, distributed=false)
+T = eltype(H)
+_H = Matrix(H; global_index=false)
+R = RkMatrix(rand(T, N, r), rand(T, N, r))
+_R = Matrix(R)
+M = rand(T, N, N)
+_M = Matrix(M)
+a = rand()
 
 @testset "axpy!" begin
-    @test axpy!(a,M,deepcopy(R)) ≈ a*_M + _R
-    tmp = axpy!(a,M,deepcopy(H))
-    @test Matrix(tmp;global_index=false) ≈ a*_M + _H
-    @test axpy!(a,R,deepcopy(M)) ≈ a*_R + _M
-    @test axpy!(a,R,deepcopy(R)) ≈ a*_R + _R
-    tmp = axpy!(a,R,deepcopy(H))
-    Matrix(tmp;global_index=false) ≈ a*_R + _H
-    @test axpy!(a,H,deepcopy(M)) ≈ a*_H + _M
-    @test axpy!(a,H,deepcopy(R)) ≈ a*_H + _R
-    tmp = axpy!(a,H,deepcopy(H))
-    @test Matrix(tmp;global_index=false) ≈ a*_H + _H
+    @test axpy!(a, M, deepcopy(R)) ≈ a * _M + _R
+    tmp = axpy!(a, M, deepcopy(H))
+    @test Matrix(tmp; global_index=false) ≈ a * _M + _H
+    @test axpy!(a, R, deepcopy(M)) ≈ a * _R + _M
+    @test axpy!(a, R, deepcopy(R)) ≈ a * _R + _R
+    tmp = axpy!(a, R, deepcopy(H))
+    Matrix(tmp; global_index=false) ≈ a * _R + _H
+    @test axpy!(a, H, deepcopy(M)) ≈ a * _H + _M
+    @test axpy!(a, H, deepcopy(R)) ≈ a * _H + _R
+    tmp = axpy!(a, H, deepcopy(H))
+    @test Matrix(tmp; global_index=false) ≈ a * _H + _H
 end

--- a/test/clustertree_test.jl
+++ b/test/clustertree_test.jl
@@ -1,0 +1,76 @@
+using Test
+using StaticArrays
+using HMatrices
+
+# recursively check that all point in a cluster tree are in the bounding box
+function test_cluster_tree(clt)
+    bbox = HMatrices.container(clt)
+    for iloc in HMatrices.index_range(clt)
+        x = HMatrices.root_elements(clt)[iloc]
+        x ∈ bbox || (return false)
+    end
+    if !HMatrices.isroot(clt)
+        clt ∈ clt.parent.children || (return false)
+    end
+    if !HMatrices.isleaf(clt)
+        for child in clt.children
+            test_cluster_tree(child) || (return false)
+        end
+    end
+    return true
+end
+
+@testset "ClusterTree" begin
+    @testset "1d" begin
+        points = SVector.([4, 3, 1, 2, 5, -1.0])
+        splitter = HMatrices.GeometricSplitter(; nmax=1)
+        clt = HMatrices.ClusterTree(points, splitter)
+        @test sortperm(points) == clt.loc2glob
+        splitter = HMatrices.CardinalitySplitter(; nmax=1)
+        clt = HMatrices.ClusterTree(points, splitter)
+        @test sortperm(points) == clt.loc2glob
+        splitter = HMatrices.PrincipalComponentSplitter(; nmax=1)
+        clt = HMatrices.ClusterTree(points, splitter)
+        @test sortperm(points) == clt.loc2glob
+    end
+
+    @testset "2d" begin
+        points = rand(SVector{2,Float64}, 1000)
+        splitter = HMatrices.GeometricSplitter(; nmax=1)
+        clt = HMatrices.ClusterTree(points, splitter)
+        @test test_cluster_tree(clt)
+        splitter = HMatrices.CardinalitySplitter(; nmax=32)
+        clt = HMatrices.ClusterTree(points, splitter)
+        @test test_cluster_tree(clt)
+        splitter = HMatrices.PrincipalComponentSplitter(; nmax=32)
+        clt = HMatrices.ClusterTree(points, splitter)
+        @test test_cluster_tree(clt)
+    end
+
+    @testset "3d" begin
+        points = rand(SVector{3,Float64}, 1000)
+        splitter = HMatrices.GeometricSplitter(; nmax=32)
+        clt = HMatrices.ClusterTree(points, splitter)
+        @test test_cluster_tree(clt)
+        splitter = HMatrices.CardinalitySplitter(; nmax=32)
+        clt = HMatrices.ClusterTree(points, splitter)
+        @test test_cluster_tree(clt)
+        splitter = HMatrices.PrincipalComponentSplitter(; nmax=32)
+        clt = HMatrices.ClusterTree(points, splitter)
+        @test test_cluster_tree(clt)
+    end
+
+    @testset "3d + threads" begin
+        threads = true
+        points = rand(SVector{3,Float64}, 1000)
+        splitter = HMatrices.GeometricSplitter(; nmax=32)
+        clt = HMatrices.ClusterTree(points, splitter; threads)
+        @test test_cluster_tree(clt)
+        splitter = HMatrices.CardinalitySplitter(; nmax=32)
+        clt = HMatrices.ClusterTree(points, splitter; threads)
+        @test test_cluster_tree(clt)
+        splitter = HMatrices.PrincipalComponentSplitter(; nmax=32)
+        clt = HMatrices.ClusterTree(points, splitter; threads)
+        @test test_cluster_tree(clt)
+    end
+end

--- a/test/compressor_test.jl
+++ b/test/compressor_test.jl
@@ -4,142 +4,141 @@ using StaticArrays
 using LinearAlgebra
 using HMatrices: ACA, PartialACA, TSVD, RkMatrix
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 using Random
 Random.seed!(1)
 
 @testset "Scalar" begin
     T = ComplexF64
-    m,n = 100,100
-    X = rand(SVector{3,Float64},m)
-    Y = map(i->SVector(10,0,0) + rand(SVector{3,Float64}),1:n)
-    K = helmholtz_matrix(X,Y,1.0)
+    m, n = 100, 100
+    X = rand(SVector{3,Float64}, m)
+    Y = map(i -> SVector(10, 0, 0) + rand(SVector{3,Float64}), 1:n)
+    K = helmholtz_matrix(X, Y, 1.0)
     M = Matrix(K)
-    irange,jrange = 1:m,1:n
+    irange, jrange = 1:m, 1:n
     @testset "aca_full" begin
         atol = 1e-5
-        aca = ACA(atol=atol)
-        R = aca(K,irange,jrange)
+        aca = ACA(; atol=atol)
+        R = aca(K, irange, jrange)
         @test norm(Matrix(R) - M) < atol
         rtol = 1e-5
-        aca = ACA(rtol=rtol)
-        R   = aca(M,irange,jrange)
+        aca = ACA(; rtol=rtol)
+        R = aca(M, irange, jrange)
         norm(Matrix(R) - M)
-        @test norm(Matrix(R) - M) < rtol*norm(M)
+        @test norm(Matrix(R) - M) < rtol * norm(M)
         r = 10
-        aca = ACA(rank=r)
-        R = aca(M,irange,jrange)
+        aca = ACA(; rank=r)
+        R = aca(M, irange, jrange)
         @test rank(R) == r
     end
     @testset "aca_partial" begin
         atol = 1e-5
-        aca = PartialACA(atol=atol)
-        R = aca(M,irange,jrange)
+        aca = PartialACA(; atol=atol)
+        R = aca(M, irange, jrange)
         @test norm(Matrix(R) - M) < atol
         rtol = 1e-5
-        aca = PartialACA(rtol=rtol)
-        R = aca(M,irange,jrange)
-        @test norm(Matrix(R) - M) < rtol*norm(M)
+        aca = PartialACA(; rtol=rtol)
+        R = aca(M, irange, jrange)
+        @test norm(Matrix(R) - M) < rtol * norm(M)
         r = 10
-        aca = PartialACA(rank=r)
-        R = aca(M,irange,jrange)
+        aca = PartialACA(; rank=r)
+        R = aca(M, irange, jrange)
         @test rank(R) == r
 
         # test fast update of frobenius norm
-        m,n = 10000,1000
+        m, n = 10000, 1000
         r = 10
         T = ComplexF64
-        A = [rand(T,m) for _ in 1:r]
-        B = [rand(T,n) for _ in 1:r]
-        R = RkMatrix(A,B)
-        old_norm = norm(Matrix(R),2)
-        push!(A,rand(T,m))
-        push!(B,rand(T,n))
-        Rnew = RkMatrix(A,B)
-        new_norm = norm(Matrix(Rnew),2)
-        @test new_norm ≈ HMatrices._update_frob_norm(old_norm,A,B)
+        A = [rand(T, m) for _ in 1:r]
+        B = [rand(T, n) for _ in 1:r]
+        R = RkMatrix(A, B)
+        old_norm = norm(Matrix(R), 2)
+        push!(A, rand(T, m))
+        push!(B, rand(T, n))
+        Rnew = RkMatrix(A, B)
+        new_norm = norm(Matrix(Rnew), 2)
+        @test new_norm ≈ HMatrices._update_frob_norm(old_norm, A, B)
 
         # test simple case where things are not compressible
-        A  = rand(2,2)
-        comp = PartialACA(rtol=1e-5)
-        @test comp(A,1:2,1:2) ≈ A
+        A = rand(2, 2)
+        comp = PartialACA(; rtol=1e-5)
+        @test comp(A, 1:2, 1:2) ≈ A
     end
     @testset "truncated svd" begin
         atol = 1e-5
-        tsvd = TSVD(atol=atol)
-        R    = tsvd(M,irange,jrange)
+        tsvd = TSVD(; atol=atol)
+        R = tsvd(M, irange, jrange)
         # the inequality below is guaranteed to be true  for  the spectral norm
         # i.e. (the `opnorm` with `p=2`).
         @test opnorm(Matrix(R) - M) < atol
         rtol = 1e-5
-        tsvd = TSVD(rtol=rtol)
-        R    = tsvd(M,irange,jrange)
-        @test opnorm(Matrix(R) - M) < rtol*opnorm(M)
+        tsvd = TSVD(; rtol=rtol)
+        R = tsvd(M, irange, jrange)
+        @test opnorm(Matrix(R) - M) < rtol * opnorm(M)
         r = 10
-        tsvd = TSVD(rank=r)
-        R  = tsvd(M,irange,jrange)
+        tsvd = TSVD(; rank=r)
+        R = tsvd(M, irange, jrange)
         @test rank(R) == r
     end
 end
 
-
 @testset "Tensorial" begin
     T = SMatrix{3,3,ComplexF64,9}
     # T = SMatrix{3,3,Float64,9}
-    m,n = 100,100
-    X = rand(SVector{3,Float64},m)
-    Y = map(i->SVector(10,0,0) + rand(SVector{3,Float64}),1:n)
-    K = elastosdynamic_matrix(X,Y,1.0,2.0,1.0,1.0)
+    m, n = 100, 100
+    X = rand(SVector{3,Float64}, m)
+    Y = map(i -> SVector(10, 0, 0) + rand(SVector{3,Float64}), 1:n)
+    K = elastosdynamic_matrix(X, Y, 1.0, 2.0, 1.0, 1.0)
     # K = ElastostaticMatrix(X,Y,1.0,2.0)
     M = Matrix(K)
-    irange,jrange = 1:m,1:n
+    irange, jrange = 1:m, 1:n
     @testset "aca_full" begin
         atol = 1e-5
-        aca = ACA(atol=atol)
-        R = aca(K,irange,jrange);
+        aca = ACA(; atol=atol)
+        R = aca(K, irange, jrange)
         @test norm(Matrix(R) - M) < atol
         rtol = 1e-5
-        aca = ACA(rtol=rtol)
-        R   = aca(M,irange,jrange)
+        aca = ACA(; rtol=rtol)
+        R = aca(M, irange, jrange)
         norm(Matrix(R) - M)
-        @test norm(Matrix(R) - M) < rtol*norm(M)
+        @test norm(Matrix(R) - M) < rtol * norm(M)
         r = 10
-        aca = ACA(rank=r)
-        R = aca(M,irange,jrange);
+        aca = ACA(; rank=r)
+        R = aca(M, irange, jrange)
         @test rank(R) == r
     end
     @testset "aca_partial" begin
         atol = 1e-5
-        aca = PartialACA(atol=atol)
-        R = aca(M,irange,jrange)
+        aca = PartialACA(; atol=atol)
+        R = aca(M, irange, jrange)
         @test norm(Matrix(R) - M) < atol
         rtol = 1e-5
-        aca = PartialACA(rtol=rtol)
-        R = aca(M,irange,jrange)
-        @test norm(Matrix(R) - M) < rtol*norm(M)
+        aca = PartialACA(; rtol=rtol)
+        R = aca(M, irange, jrange)
+        @test norm(Matrix(R) - M) < rtol * norm(M)
         r = 10
-        aca = PartialACA(rank=r)
-        R = aca(M,irange,jrange);
+        aca = PartialACA(; rank=r)
+        R = aca(M, irange, jrange)
         @test rank(R) == r
 
         # test fast update of frobenius norm
-        m,n = 10000,1000
+        m, n = 10000, 1000
         r = 10
         T = ComplexF64
-        A = [rand(T,m) for _ in 1:r]
-        B = [rand(T,n) for _ in 1:r]
-        R = RkMatrix(A,B)
-        old_norm = norm(Matrix(R),2)
-        push!(A,rand(T,m))
-        push!(B,rand(T,n))
-        Rnew = RkMatrix(A,B)
-        new_norm = norm(Matrix(Rnew),2)
-        @test new_norm ≈ HMatrices._update_frob_norm(old_norm,A,B)
+        A = [rand(T, m) for _ in 1:r]
+        B = [rand(T, n) for _ in 1:r]
+        R = RkMatrix(A, B)
+        old_norm = norm(Matrix(R), 2)
+        push!(A, rand(T, m))
+        push!(B, rand(T, n))
+        Rnew = RkMatrix(A, B)
+        new_norm = norm(Matrix(Rnew), 2)
+        @test new_norm ≈ HMatrices._update_frob_norm(old_norm, A, B)
 
         # test simple case where things are not compressible
-        A  = rand(2,2)
-        comp = PartialACA(rtol=1e-5)
-        @test comp(A,1:2,1:2) ≈ A
+        A = rand(2, 2)
+        comp = PartialACA(; rtol=1e-5)
+        @test comp(A, 1:2, 1:2) ≈ A
     end
 end

--- a/test/dhmatrix_test.jl
+++ b/test/dhmatrix_test.jl
@@ -4,21 +4,21 @@ addprocs(4; exeflags=`--project=$(Base.active_project())`)
 using Test
 using StaticArrays
 @everywhere using HMatrices
-@everywhere include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+@everywhere include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 @testset "Assemble" begin
-    m,n  = 10_000,10_000
-    X  = Y    = points_on_cylinder(1,m)
-    splitter  = CardinalitySplitter(nmax=100)
-    Xclt = Yclt = ClusterTree(X,splitter)
-    adm       = StrongAdmissibilityStd(eta=3)
-    atol      = 1e-6
-    comp      = PartialACA(;atol)
+    m, n = 10_000, 10_000
+    X = Y = points_on_cylinder(1, m)
+    splitter = CardinalitySplitter(; nmax=100)
+    Xclt = Yclt = ClusterTree(X, splitter)
+    adm = StrongAdmissibilityStd(; eta=3)
+    atol = 1e-6
+    comp = PartialACA(; atol)
     # Laplace
-    K         = laplace_matrix(X,Y)
-    H         = assemble_hmat(K,Xclt,Yclt;adm,comp,distributed=false,threads=true)
-    Hd        = assemble_hmat(K,Xclt,Yclt;adm,comp,distributed=true,threads=false)
+    K = laplace_matrix(X, Y)
+    H = assemble_hmat(K, Xclt, Yclt; adm, comp, distributed=false, threads=true)
+    Hd = assemble_hmat(K, Xclt, Yclt; adm, comp, distributed=true, threads=false)
     x = rand(n)
     y = rand(m)
-    @test H*x ≈ Hd*x
+    @test H * x ≈ Hd * x
 end

--- a/test/hmatrix_test.jl
+++ b/test/hmatrix_test.jl
@@ -3,38 +3,38 @@ using StaticArrays
 using HMatrices
 using LinearAlgebra
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 @testset "Assemble" begin
-    m,n  = 1_000,1_000
-    X  = Y   = rand(SVector{3,Float64},m)
-    splitter  = CardinalitySplitter(nmax=20)
-    Xclt = Yclt = ClusterTree(X,splitter)
-    adm       = StrongAdmissibilityStd(eta=3)
-    rtol      = 1e-5
-    comp      = PartialACA(rtol=rtol)
+    m, n = 1_000, 1_000
+    X = Y = rand(SVector{3,Float64}, m)
+    splitter = CardinalitySplitter(; nmax=20)
+    Xclt = Yclt = ClusterTree(X, splitter)
+    adm = StrongAdmissibilityStd(; eta=3)
+    rtol = 1e-5
+    comp = PartialACA(; rtol=rtol)
     # Laplace
-    for threads in (true,false)
-        K         = laplace_matrix(X,Y)
-        H         = assemble_hmat(K,Xclt,Yclt;adm,comp,threads)
-        @test norm(Matrix(K) - Matrix(H;global_index=true)) < rtol*norm(Matrix(K))
-        H         = assemble_hmat(K;threads,distributed=false)
-        @test norm(Matrix(K) - Matrix(H;global_index=true)) < rtol*norm(Matrix(K))
-        adjH      = adjoint(H)
-        H_full    = Matrix(H;global_index=false)
+    for threads in (true, false)
+        K = laplace_matrix(X, Y)
+        H = assemble_hmat(K, Xclt, Yclt; adm, comp, threads)
+        @test norm(Matrix(K) - Matrix(H; global_index=true)) < rtol * norm(Matrix(K))
+        H = assemble_hmat(K; threads, distributed=false)
+        @test norm(Matrix(K) - Matrix(H; global_index=true)) < rtol * norm(Matrix(K))
+        adjH = adjoint(H)
+        H_full = Matrix(H; global_index=false)
         adjH_full = adjoint(H_full)
         @testset "getindex" begin
             HMatrices.enable_getindex()
-            @test H_full[8,64] ≈ H[8,64]
+            @test H_full[8, 64] ≈ H[8, 64]
             HMatrices.disable_getindex()
-            @test_throws ErrorException H_full[8,64] ≈ H[8,64]
+            @test_throws ErrorException H_full[8, 64] ≈ H[8, 64]
             HMatrices.enable_getindex()
-            @test H_full[:,666] ≈ H[:,666]
-            @test adjH_full[:,666] ≈ adjH[:,666]
+            @test H_full[:, 666] ≈ H[:, 666]
+            @test adjH_full[:, 666] ≈ adjH[:, 666]
         end
         # Elastostatic
-        K         = elastostatic_matrix(X,Y,1.1,1.2)
-        H         = assemble_hmat(K,Xclt,Yclt;adm,comp,threads)
-        @test norm(Matrix(K) - Matrix(H;global_index=true)) < rtol*norm(Matrix(K))
+        K = elastostatic_matrix(X, Y, 1.1, 1.2)
+        H = assemble_hmat(K, Xclt, Yclt; adm, comp, threads)
+        @test norm(Matrix(K) - Matrix(H; global_index=true)) < rtol * norm(Matrix(K))
     end
 end

--- a/test/hyperrectangle_test.jl
+++ b/test/hyperrectangle_test.jl
@@ -1,0 +1,52 @@
+using Test
+using HMatrices
+using StaticArrays
+
+@testset "HyperRectangle tests" begin
+    low_corner = SVector(0.0, 0.0)
+    high_corner = SVector(1.0, 2.0)
+    mid = (low_corner + high_corner) / 2
+    rec = HMatrices.HyperRectangle(low_corner, high_corner)
+    @test mid == HMatrices.center(rec)
+    @test high_corner ∈ rec
+    @test low_corner ∈ rec
+    @test mid ∈ rec
+    @test !in(high_corner + SVector(1, 1), rec)
+    rec1, rec2 = split(rec)
+    @test low_corner ∈ rec1
+    @test high_corner ∈ rec2
+    @test !(low_corner ∈ rec2)
+    @test !(high_corner ∈ rec1)
+    @test HMatrices.diameter(rec) == sqrt(1^2 + 2^2)
+    @test HMatrices.radius(rec) == sqrt(1^2 + 2^2) / 2
+    # bbox
+    pts = SVector{2,Float64}[]
+    for x in -1:0.1:1
+        for y in -1:0.1:1
+            push!(pts, SVector(x, y))
+        end
+    end
+    @test HMatrices.bounding_box(pts) == HMatrices.HyperRectangle(SVector(-1.0, -1), SVector(1, 1.0))
+    @test HMatrices.bounding_box(pts, true) ==
+          HMatrices.HyperRectangle(SVector(-1.0, -1), SVector(1, 1.0))
+    pts = SVector{2,Float64}[]
+    for x in -1:0.1:1
+        for y in -1:0.1:2
+            push!(pts, SVector(x, y))
+        end
+    end
+    @test HMatrices.bounding_box(pts) == HMatrices.HyperRectangle(SVector(-1.0, -1), SVector(1, 2.0))
+    @test HMatrices.bounding_box(pts, true) ==
+          HMatrices.HyperRectangle(SVector(-1.5, -1), SVector(3 / 2, 2.0))
+    rec1 = HMatrices.HyperRectangle(SVector(0, 0), SVector(1, 1))
+    rec2 = HMatrices.HyperRectangle(SVector(2, 0), SVector(3, 1))
+    @test HMatrices.distance(rec1, rec2) ≈ 1
+    x = SVector(0.5, 0.5)
+    @test HMatrices.distance(x, rec1) ≈ HMatrices.distance(rec1, x) ≈ 0
+    x = SVector(0.0, 2.0)
+    @test HMatrices.distance(x, rec1) ≈ HMatrices.distance(rec1, x) ≈ 1
+    x = SVector(2.0, 2.0)
+    @test HMatrices.distance(x, rec1) ≈ HMatrices.distance(rec1, x) ≈ √2
+    rec2 = HMatrices.HyperRectangle(SVector(2, 2), SVector(3, 3))
+    HMatrices.distance(rec1, rec2) ≈ sqrt(2)
+end

--- a/test/hyperrectangle_test.jl
+++ b/test/hyperrectangle_test.jl
@@ -26,7 +26,8 @@ using StaticArrays
             push!(pts, SVector(x, y))
         end
     end
-    @test HMatrices.bounding_box(pts) == HMatrices.HyperRectangle(SVector(-1.0, -1), SVector(1, 1.0))
+    @test HMatrices.bounding_box(pts) ==
+          HMatrices.HyperRectangle(SVector(-1.0, -1), SVector(1, 1.0))
     @test HMatrices.bounding_box(pts, true) ==
           HMatrices.HyperRectangle(SVector(-1.0, -1), SVector(1, 1.0))
     pts = SVector{2,Float64}[]
@@ -35,7 +36,8 @@ using StaticArrays
             push!(pts, SVector(x, y))
         end
     end
-    @test HMatrices.bounding_box(pts) == HMatrices.HyperRectangle(SVector(-1.0, -1), SVector(1, 2.0))
+    @test HMatrices.bounding_box(pts) ==
+          HMatrices.HyperRectangle(SVector(-1.0, -1), SVector(1, 2.0))
     @test HMatrices.bounding_box(pts, true) ==
           HMatrices.HyperRectangle(SVector(-1.5, -1), SVector(3 / 2, 2.0))
     rec1 = HMatrices.HyperRectangle(SVector(0, 0), SVector(1, 1))

--- a/test/lu_test.jl
+++ b/test/lu_test.jl
@@ -6,29 +6,29 @@ using StaticArrays
 
 using HMatrices: RkMatrix
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 Random.seed!(1)
 
 m = 5000
 T = Float64
-X    = points_on_sphere(m)
-Y    = X
+X = points_on_sphere(m)
+Y = X
 
-K = laplace_matrix(X,X)
+K = laplace_matrix(X, X)
 
-splitter  = CardinalitySplitter(nmax=50)
-Xclt      = ClusterTree(X,splitter)
-Yclt      = ClusterTree(Y,splitter)
+splitter = CardinalitySplitter(; nmax=50)
+Xclt = ClusterTree(X, splitter)
+Yclt = ClusterTree(Y, splitter)
 adm = StrongAdmissibilityStd(3)
-comp = PartialACA(;atol=1e-10);
-H = assemble_hmat(K,Xclt,Yclt;adm,comp,threads=false,distributed=false)
-H_full      = Matrix(H)
+comp = PartialACA(; atol=1e-10);
+H = assemble_hmat(K, Xclt, Yclt; adm, comp, threads=false, distributed=false)
+H_full = Matrix(H)
 
 ##
-hlu   = lu(H;atol=1e-5)
-y     = rand(m)
-M     = Matrix(K)
-exact = M\y
-approx = hlu\y
-@test norm(exact - approx,Inf) < 1e-6
+hlu = lu(H; atol=1e-5)
+y = rand(m)
+M = Matrix(K)
+exact = M \ y
+approx = hlu \ y
+@test norm(exact - approx, Inf) < 1e-6

--- a/test/multiplication_test.jl
+++ b/test/multiplication_test.jl
@@ -6,59 +6,58 @@ using StaticArrays
 
 using HMatrices: RkMatrix
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 Random.seed!(1)
 
 m = 2000
 n = 2000
 
-X    = rand(SVector{3,Float64},m)
-Y    = [rand(SVector{3,Float64}) for _  in 1:n]
-splitter  = CardinalitySplitter(nmax=40)
-Xclt      = ClusterTree(X,splitter)
-Yclt      = ClusterTree(Y,splitter)
-adm       = StrongAdmissibilityStd(eta=3)
-rtol      = 1e-5
-comp      = PartialACA(rtol=rtol)
-K         = laplace_matrix(X,Y)
-H         = assemble_hmat(K,Xclt,Yclt;adm,comp,threads=false,distributed=false)
+X = rand(SVector{3,Float64}, m)
+Y = [rand(SVector{3,Float64}) for _ in 1:n]
+splitter = CardinalitySplitter(; nmax=40)
+Xclt = ClusterTree(X, splitter)
+Yclt = ClusterTree(Y, splitter)
+adm = StrongAdmissibilityStd(; eta=3)
+rtol = 1e-5
+comp = PartialACA(; rtol=rtol)
+K = laplace_matrix(X, Y)
+H = assemble_hmat(K, Xclt, Yclt; adm, comp, threads=false, distributed=false)
 
-H_full = Matrix(H;global_index=false)
+H_full = Matrix(H; global_index=false)
 
 α = rand() - 0.5
 β = rand() - 0.5
 @testset "hmul!" begin
-    C  = deepcopy(H);
-    tmp = β*H_full + α*H_full*H_full
-    HMatrices.hmul!(C,H,H,α,β,PartialACA(;atol=1e-6))
-    @test Matrix(C;global_index=false) ≈ tmp
+    C = deepcopy(H)
+    tmp = β * H_full + α * H_full * H_full
+    HMatrices.hmul!(C, H, H, α, β, PartialACA(; atol=1e-6))
+    @test Matrix(C; global_index=false) ≈ tmp
 end
 
 @testset "gemv" begin
-
-    α = rand()-0.5
-    β = rand()-0.5
+    α = rand() - 0.5
+    β = rand() - 0.5
     T = eltype(H)
-    m,n = size(H)
-    x = rand(T,n)
-    y = rand(T,m)
+    m, n = size(H)
+    x = rand(T, n)
+    y = rand(T, m)
 
     @testset "serial" begin
-        exact  = β*y + α*H_full*x
-        approx = mul!(copy(y),H,x,α,β;threads=false,global_index=false)
+        exact = β * y + α * H_full * x
+        approx = mul!(copy(y), H, x, α, β; threads=false, global_index=false)
         @test exact ≈ approx
-        exact  = β*y + α*Matrix(H;global_index=true)*x
-        approx = mul!(copy(y),H,x,α,β;threads=false,global_index=true)
+        exact = β * y + α * Matrix(H; global_index=true) * x
+        approx = mul!(copy(y), H, x, α, β; threads=false, global_index=true)
         @test exact ≈ approx
     end
 
     @testset "threads" begin
-        exact  = β*y + α*H_full*x
-        approx = mul!(copy(y),H,x,α,β;threads=true,global_index=false)
+        exact = β * y + α * H_full * x
+        approx = mul!(copy(y), H, x, α, β; threads=true, global_index=false)
         @test exact ≈ approx
-        exact  = β*y + α*Matrix(H;global_index=true)*x
-        approx = mul!(copy(y),H,x,α,β;threads=false,global_index=true)
+        exact = β * y + α * Matrix(H; global_index=true) * x
+        approx = mul!(copy(y), H, x, α, β; threads=false, global_index=true)
         @test exact ≈ approx
     end
 end

--- a/test/rkmatrix_test.jl
+++ b/test/rkmatrix_test.jl
@@ -9,20 +9,20 @@ using HMatrices: RkMatrix, compression_ratio
         m = 20
         n = 30
         r = 5
-        A = rand(ComplexF64,m,r)
-        B = rand(ComplexF64,n,r)
-        R  = RkMatrix(A,B);
-        Ra  = adjoint(R);
-        M  = A*adjoint(B)
-        Ma  = adjoint(M)
+        A = rand(ComplexF64, m, r)
+        B = rand(ComplexF64, n, r)
+        R = RkMatrix(A, B)
+        Ra = adjoint(R)
+        M = A * adjoint(B)
+        Ma = adjoint(M)
 
         ## basic tests
-        @test size(R) == (m,n)
+        @test size(R) == (m, n)
         @test rank(R) == r
         @test Matrix(R) ≈ M
-        @test compression_ratio(R) ≈ m*n / (r*(m+n))
-        @test R[:,5] ≈ M[:,5]
-        @test Ra[:,5] ≈ Ma[:,5]
+        @test compression_ratio(R) ≈ m * n / (r * (m + n))
+        @test R[:, 5] ≈ M[:, 5]
+        @test Ra[:, 5] ≈ Ma[:, 5]
     end
 
     @testset "Matrix entries" begin
@@ -30,12 +30,12 @@ using HMatrices: RkMatrix, compression_ratio
         n = 30
         r = 10
         T = SMatrix{3,3,ComplexF64,9}
-        A = rand(T,m,r)
-        B = rand(T,n,r)
-        R  = RkMatrix(A,B)
+        A = rand(T, m, r)
+        B = rand(T, n, r)
+        R = RkMatrix(A, B)
         ## basic tests
-        @test size(R) == (m,n)
+        @test size(R) == (m, n)
         @test rank(R) == r
-        @test compression_ratio(R) ≈ m*n / (r*(m+n))
+        @test compression_ratio(R) ≈ m * n / (r * (m + n))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,10 @@ using SafeTestsets
 
 @safetestset "Utils" begin include("utils_test.jl") end
 
+@safetestset "HyperRectangle" begin include("hyperrectangle_test.jl") end
+
+@safetestset "ClusterTree" begin include("clustertree_test.jl") end
+
 @safetestset "RkMatrix" begin include("rkmatrix_test.jl") end
 
 @safetestset "Compressors" begin include("compressor_test.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,23 +1,43 @@
 using SafeTestsets
 
-@safetestset "Utils" begin include("utils_test.jl") end
+@safetestset "Utils" begin
+    include("utils_test.jl")
+end
 
-@safetestset "HyperRectangle" begin include("hyperrectangle_test.jl") end
+@safetestset "HyperRectangle" begin
+    include("hyperrectangle_test.jl")
+end
 
-@safetestset "ClusterTree" begin include("clustertree_test.jl") end
+@safetestset "ClusterTree" begin
+    include("clustertree_test.jl")
+end
 
-@safetestset "RkMatrix" begin include("rkmatrix_test.jl") end
+@safetestset "RkMatrix" begin
+    include("rkmatrix_test.jl")
+end
 
-@safetestset "Compressors" begin include("compressor_test.jl") end
+@safetestset "Compressors" begin
+    include("compressor_test.jl")
+end
 
-@safetestset "HMatrix" begin include("hmatrix_test.jl") end
+@safetestset "HMatrix" begin
+    include("hmatrix_test.jl")
+end
 
-@safetestset "Addition" begin include("addition_test.jl") end
+@safetestset "Addition" begin
+    include("addition_test.jl")
+end
 
-@safetestset "Multiplication" begin include("multiplication_test.jl") end
+@safetestset "Multiplication" begin
+    include("multiplication_test.jl")
+end
 
-@safetestset "Triangular" begin include("triangular_test.jl") end
+@safetestset "Triangular" begin
+    include("triangular_test.jl")
+end
 
-@safetestset "LU" begin include("lu_test.jl") end
+@safetestset "LU" begin
+    include("lu_test.jl")
+end
 
 # @safetestset "DHMatrix" begin include("dhmatrix_test.jl") end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -12,8 +12,8 @@ function laplace_matrix(X, Y)
         d = norm(x - y) + EPS
         inv(4π * d)
     end
-    KernelMatrix(f, X, Y)
-    end
+    return KernelMatrix(f, X, Y)
+end
 
 function helmholtz_matrix(X, Y, k)
     f = (x, y) -> begin
@@ -21,7 +21,7 @@ function helmholtz_matrix(X, Y, k)
         d = norm(x - y) + EPS
         exp(im * k * d) * inv(4π * d)
     end
-    KernelMatrix(f, X, Y)
+    return KernelMatrix(f, X, Y)
 end
 
 function elastostatic_matrix(X, Y, μ, λ)
@@ -32,7 +32,7 @@ function elastostatic_matrix(X, Y, μ, λ)
         RRT = r * transpose(r) # r ⊗ rᵗ
         return 1 / (16π * μ * (1 - ν) * d) * ((3 - 4 * ν) * I + RRT / d^2)
     end
-    KernelMatrix(f, X, Y)
+    return KernelMatrix(f, X, Y)
 end
 
 function elastosdynamic_matrix(X, Y, μ, λ, ω, ρ)
@@ -40,17 +40,18 @@ function elastosdynamic_matrix(X, Y, μ, λ, ω, ρ)
         c1 = sqrt((λ + 2μ) / ρ)
         c2 = sqrt(μ / ρ)
         r = x - y
-        d   = norm(r) + EPS
+        d = norm(r) + EPS
         RRT = r * transpose(r) # r ⊗ rᵗ
-        s   = -im * ω
-        z1  = s * d / c1
-        z2  = s * d / c2
-        α   = 4
-        ψ   = exp(-z2) / d + (1 + z2) / (z2^2) * exp(-z2) / d - c2^2 / c1^2 * (1 + z1) / (z1^2) * exp(-z1) / d
+        s = -im * ω
+        z1 = s * d / c1
+        z2 = s * d / c2
+        α = 4
+        ψ = exp(-z2) / d + (1 + z2) / (z2^2) * exp(-z2) / d -
+            c2^2 / c1^2 * (1 + z1) / (z1^2) * exp(-z1) / d
         chi = 3 * ψ - 2 * exp(-z2) / d - c2^2 / c1^2 * exp(-z1) / d
         return 1 / (α * π * μ) * (ψ * I - chi * RRT / d^2) + x * transpose(y)
     end
-    KernelMatrix(f, X, Y)
+    return KernelMatrix(f, X, Y)
 end
 
 """
@@ -63,22 +64,23 @@ struct LaplaceMatrixVec{T,Td} <: AbstractKernelMatrix{T}
     Y::Matrix{Td}
     function LaplaceMatrixVec{T}(X::Matrix{Td}, Y::Matrix{Td}) where {T,Td}
         @assert size(X, 2) == size(Y, 2) == 3
-        new{T,Td}(X, Y)
+        return new{T,Td}(X, Y)
     end
 end
 
 Base.size(K::LaplaceMatrixVec) = size(K.X, 1), size(K.Y, 1)
 
 # constructor based on Vector of StaticVector
-function LaplaceMatrixVec{T}(_X::Vector{SVector{3,Td}}, _Y::Vector{SVector{3,Td}}) where {T,Td}
-    X = reshape(reinterpret(Td, _X), 3, :) |> transpose |> collect
-    Y = reshape(reinterpret(Td, _Y), 3, :) |> transpose |> collect
-    LaplaceMatrixVec{T}(X, Y)
+function LaplaceMatrixVec{T}(_X::Vector{SVector{3,Td}},
+                             _Y::Vector{SVector{3,Td}}) where {T,Td}
+    X = collect(transpose(reshape(reinterpret(Td, _X), 3, :)))
+    Y = collect(transpose(reshape(reinterpret(Td, _Y), 3, :)))
+    return LaplaceMatrixVec{T}(X, Y)
 end
 LaplaceMatrixVec(args...) = LaplaceMatrixVec{Float64}(args...) # default to Float64
 
 function Base.getindex(K::LaplaceMatrixVec{T}, i::Int, j::Int)::T where {T}
-    d2 = (K.X[i,1] - K.Y[j,1])^2 + (K.X[i,2] - K.Y[j,2])^2 + (K.X[i,3] - K.Y[j,3])^2
+    d2 = (K.X[i, 1] - K.Y[j, 1])^2 + (K.X[i, 2] - K.Y[j, 2])^2 + (K.X[i, 3] - K.Y[j, 3])^2
     d = sqrt(d2) + EPS
     return inv(4π * d)
 end
@@ -91,21 +93,21 @@ function Base.getindex(K::LaplaceMatrixVec, I::UnitRange, J::UnitRange)
     out = Matrix{T}(undef, m, n)
     @avx for j in 1:n
         for i in 1:m
-            d2 = (Xv[i,1] - Yv[j,1])^2
-            d2 += (Xv[i,2] - Yv[j,2])^2
-            d2 += (Xv[i,3] - Yv[j,3])^2
+            d2 = (Xv[i, 1] - Yv[j, 1])^2
+            d2 += (Xv[i, 2] - Yv[j, 2])^2
+            d2 += (Xv[i, 3] - Yv[j, 3])^2
             d = sqrt(d2) + EPS
-            out[i,j] = inv(4 * π * d)
+            out[i, j] = inv(4 * π * d)
         end
     end
     return out
 end
 function Base.getindex(K::LaplaceMatrixVec, I::UnitRange, j::Int)
-    return vec(K[I,j:j])
+    return vec(K[I, j:j])
 end
 function Base.getindex(adjK::Adjoint{<:Any,LaplaceMatrixVec}, I::UnitRange, j::Int)
     K = parent(adjK)
-    vec(K[j:j,I])
+    return vec(K[j:j, I])
 end
 
 """
@@ -119,25 +121,27 @@ struct HelmholtzMatrixVec{T,Td,Tk} <: AbstractKernelMatrix{T}
     k::Tk
     function HelmholtzMatrixVec{T}(X::Matrix{Td}, Y::Matrix{Td}, k::Tk) where {T,Td,Tk}
         @assert size(X, 2) == size(Y, 2) == 3
-        new{T,Td,Tk}(X, Y, k)
+        return new{T,Td,Tk}(X, Y, k)
     end
 end
 HelmholtzMatrixVec(args...) = HelmholtzMatrixVec{ComplexF64}(args...)
 
 Base.size(K::HelmholtzMatrixVec) = size(K.X, 1), size(K.Y, 1)
 
-function HelmholtzMatrixVec{T}(_X::Vector{SVector{3,Td}}, _Y::Vector{SVector{3,Td}}, k) where {T,Td}
-    X = reshape(reinterpret(Td, _X), 3, :) |> transpose |> collect
-    Y = reshape(reinterpret(Td, _Y), 3, :) |> transpose |> collect
-    HelmholtzMatrixVec{T}(X, Y, k)
+function HelmholtzMatrixVec{T}(_X::Vector{SVector{3,Td}}, _Y::Vector{SVector{3,Td}},
+                               k) where {T,Td}
+    X = collect(transpose(reshape(reinterpret(Td, _X), 3, :)))
+    Y = collect(transpose(reshape(reinterpret(Td, _Y), 3, :)))
+    return HelmholtzMatrixVec{T}(X, Y, k)
 end
 
 function Base.getindex(K::HelmholtzMatrixVec{T}, i::Int, j::Int)::T where {T}
-    d2 = (K.X[i,1] - K.Y[j,1])^2 + (K.X[i,2] - K.Y[j,2])^2 + (K.X[i,3] - K.Y[j,3])^2
-    d  = sqrt(d2) + EPS
+    d2 = (K.X[i, 1] - K.Y[j, 1])^2 + (K.X[i, 2] - K.Y[j, 2])^2 + (K.X[i, 3] - K.Y[j, 3])^2
+    d = sqrt(d2) + EPS
     return inv(4π * d) * exp(im * K.k * d)
 end
-function Base.getindex(K::HelmholtzMatrixVec{Complex{T}}, I::UnitRange, J::UnitRange) where {T}
+function Base.getindex(K::HelmholtzMatrixVec{Complex{T}}, I::UnitRange,
+                       J::UnitRange) where {T}
     k = K.k
     m = length(I)
     n = length(J)
@@ -146,55 +150,55 @@ function Base.getindex(K::HelmholtzMatrixVec{Complex{T}}, I::UnitRange, J::UnitR
     # since LoopVectorization does not (yet) support Complex{T} types, we will
     # reinterpret the output as a Matrix{T}, then use views. This can probably be
     # done better.
-    out    = Matrix{Complex{T}}(undef, m, n)
-    out_T  = reinterpret(T, out)
-    out_r = @views out_T[1:2:end,:]
-    out_i = @views out_T[2:2:end,:]
+    out = Matrix{Complex{T}}(undef, m, n)
+    out_T = reinterpret(T, out)
+    out_r = @views out_T[1:2:end, :]
+    out_i = @views out_T[2:2:end, :]
     @avx for j in 1:n
         for i in 1:m
-            d2 = (Xv[i,1] - Yv[j,1])^2
-            d2 += (Xv[i,2] - Yv[j,2])^2
-            d2 += (Xv[i,3] - Yv[j,3])^2
-            d  = sqrt(d2) + EPS
+            d2 = (Xv[i, 1] - Yv[j, 1])^2
+            d2 += (Xv[i, 2] - Yv[j, 2])^2
+            d2 += (Xv[i, 3] - Yv[j, 3])^2
+            d = sqrt(d2) + EPS
             s, c = sincos(k * d)
             zr = inv(4π * d) * c
             zi = inv(4π * d) * s
-            out_r[i,j] = zr
-            out_i[i,j] = zi
+            out_r[i, j] = zr
+            out_i[i, j] = zi
         end
     end
     return out
 end
 function Base.getindex(K::HelmholtzMatrixVec, I::UnitRange, j::Int)
-    vec(K[I,j:j])
+    return vec(K[I, j:j])
 end
 function Base.getindex(adjK::Adjoint{<:Any,<:HelmholtzMatrixVec}, I::UnitRange, j::Int)
     K = parent(adjK)
-    conj!(K[j:j,I]) |> vec
+    return vec(conj!(K[j:j, I]))
 end
 
 function points_on_sphere(npts, R=1)
     theta = π * rand(npts)
-    phi   = 2 * π * rand(npts)
-    x     = @. sin(theta) * cos(phi)
-    y     = @. R * sin(theta) * sin(phi)
-    z     = @. R * cos(theta)
-    data  = vcat(x', y', z')
-    pts = reinterpret(SVector{3,Float64}, vec(data)) |> collect
+    phi = 2 * π * rand(npts)
+    x = @. sin(theta) * cos(phi)
+    y = @. R * sin(theta) * sin(phi)
+    z = @. R * cos(theta)
+    data = vcat(x', y', z')
+    pts = collect(reinterpret(SVector{3,Float64}, vec(data)))
     return pts
 end
 
-function points_on_cylinder(radius,n,shift=SVector(0,0,0))
-    step     = 1.75*π*radius/sqrt(n)
-    result          = Vector{SVector{3,Float64}}(undef,n)
-    length          = 2*π*radius
-    pointsPerCircle = length/step
-    angleStep       = 2*π/pointsPerCircle
-    for i=0:n-1
-        x = radius * cos(angleStep*i)
-        y = radius * sin(angleStep*i)
-        z = step*i/pointsPerCircle
-        result[i+1] = shift + SVector(x,y,z)
+function points_on_cylinder(radius, n, shift=SVector(0, 0, 0))
+    step = 1.75 * π * radius / sqrt(n)
+    result = Vector{SVector{3,Float64}}(undef, n)
+    length = 2 * π * radius
+    pointsPerCircle = length / step
+    angleStep = 2 * π / pointsPerCircle
+    for i in 0:(n - 1)
+        x = radius * cos(angleStep * i)
+        y = radius * sin(angleStep * i)
+        z = step * i / pointsPerCircle
+        result[i + 1] = shift + SVector(x, y, z)
     end
     return result
 end

--- a/test/triangular_test.jl
+++ b/test/triangular_test.jl
@@ -6,74 +6,74 @@ using StaticArrays
 
 using HMatrices: RkMatrix
 
-include(joinpath(HMatrices.PROJECT_ROOT,"test","testutils.jl"))
+include(joinpath(HMatrices.PROJECT_ROOT, "test", "testutils.jl"))
 
 Random.seed!(1)
 
 m = 1000
 T = Float64
-X    = points_on_sphere(m)
-Y    = X
+X = points_on_sphere(m)
+Y = X
 struct ExponentialKernel <: AbstractMatrix{Float64}
     X::Vector{SVector{3,Float64}}
     Y::Vector{SVector{3,Float64}}
 end
-function Base.getindex(K::ExponentialKernel,i::Int,j::Int)
-    x,y = K.X[i], K.Y[j]
-    exp(-norm(x-y))
+function Base.getindex(K::ExponentialKernel, i::Int, j::Int)
+    x, y = K.X[i], K.Y[j]
+    return exp(-norm(x - y))
 end
 Base.size(K::ExponentialKernel) = length(K.X), length(K.Y)
-K = ExponentialKernel(X,X)
+K = ExponentialKernel(X, X)
 
-splitter  = CardinalitySplitter(nmax=50)
-Xclt      = ClusterTree(X,splitter)
-Yclt      = ClusterTree(Y,splitter)
-H = assemble_hmat(K,Xclt,Yclt;threads=false,distributed=false)
-H_full      = Matrix(H;global_index=false)
+splitter = CardinalitySplitter(; nmax=50)
+Xclt = ClusterTree(X, splitter)
+Yclt = ClusterTree(Y, splitter)
+H = assemble_hmat(K, Xclt, Yclt; threads=false, distributed=false)
+H_full = Matrix(H; global_index=false)
 
 @testset "ldiv!" begin
-    B = rand(m,2)
-    R = RkMatrix(rand(m,3),rand(m,3))
+    B = rand(m, 2)
+    R = RkMatrix(rand(m, 3), rand(m, 3))
     R_full = Matrix(R)
 
     ## 3.1
-    exact  = ldiv!(UnitLowerTriangular(H_full),copy(B))
-    approx = ldiv!(UnitLowerTriangular(H),copy(B))
+    exact = ldiv!(UnitLowerTriangular(H_full), copy(B))
+    approx = ldiv!(UnitLowerTriangular(H), copy(B))
     @test exact ≈ approx
 
-    exact  = ldiv!(UpperTriangular(H_full),copy(B))
-    approx = ldiv!(UpperTriangular(H),copy(B))
+    exact = ldiv!(UpperTriangular(H_full), copy(B))
+    approx = ldiv!(UpperTriangular(H), copy(B))
     @test exact ≈ approx
 
     ## 3.2
-    exact  = ldiv!(UnitLowerTriangular(H_full),copy(R_full))
-    approx = ldiv!(UnitLowerTriangular(H),copy(R))
+    exact = ldiv!(UnitLowerTriangular(H_full), copy(R_full))
+    approx = ldiv!(UnitLowerTriangular(H), copy(R))
     @test exact ≈ Matrix(approx)
 
     ## 3.3
-    compressor = PartialACA(;atol=1e-8)
-    exact      = ldiv!(UnitLowerTriangular(H_full),copy(H_full))
-    approx     = ldiv!(UnitLowerTriangular(H),deepcopy(H),compressor)
-    @test exact ≈ Matrix(approx;global_index=false)
+    compressor = PartialACA(; atol=1e-8)
+    exact = ldiv!(UnitLowerTriangular(H_full), copy(H_full))
+    approx = ldiv!(UnitLowerTriangular(H), deepcopy(H), compressor)
+    @test exact ≈ Matrix(approx; global_index=false)
 end
 
 @testset "rdiv!" begin
-    B = rand(2,m)
-    R = RkMatrix(rand(m,3),rand(m,3))
+    B = rand(2, m)
+    R = RkMatrix(rand(m, 3), rand(m, 3))
     R_full = Matrix(R)
     # 3.1
-    exact  = rdiv!(copy(B),UpperTriangular(H_full))
-    approx = rdiv!(copy(B),UpperTriangular(H))
+    exact = rdiv!(copy(B), UpperTriangular(H_full))
+    approx = rdiv!(copy(B), UpperTriangular(H))
     @test exact ≈ approx
 
     ## 3.2
-    exact  = rdiv!(copy(R_full),UpperTriangular(H_full))
-    approx = rdiv!(copy(R),UpperTriangular(H))
+    exact = rdiv!(copy(R_full), UpperTriangular(H_full))
+    approx = rdiv!(copy(R), UpperTriangular(H))
     @test exact ≈ approx
 
     ## 3.3
-    compressor = PartialACA(;atol=1e-10)
-    exact  = rdiv!(deepcopy(H_full),UpperTriangular(H_full))
-    approx = rdiv!(deepcopy(H),UpperTriangular(H),compressor)
-    @test exact ≈ Matrix(approx;global_index=false)
+    compressor = PartialACA(; atol=1e-10)
+    exact = rdiv!(deepcopy(H_full), UpperTriangular(H_full))
+    approx = rdiv!(deepcopy(H), UpperTriangular(H), compressor)
+    @test exact ≈ Matrix(approx; global_index=false)
 end

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -5,11 +5,11 @@ using HMatrices: hilbert_linear_to_cartesian, hilbert_cartesian_to_linear
 @testset "Hilbert points" begin
     # check that hilbert curves spans the lattice, and the inverse is correct
     for n in [2^p for p in 0:3]
-        lattice = Set((i,j) for i in 0:n-1,j in 0:n-1)
-        for d in 0:(n^2-1)
-            x,y = hilbert_linear_to_cartesian(n,d)
-            pop!(lattice,(x,y))
-            @test hilbert_cartesian_to_linear(n,x,y) == d
+        lattice = Set((i, j) for i in 0:(n - 1), j in 0:(n - 1))
+        for d in 0:(n^2 - 1)
+            x, y = hilbert_linear_to_cartesian(n, d)
+            pop!(lattice, (x, y))
+            @test hilbert_cartesian_to_linear(n, x, y) == d
         end
         @test isempty(lattice)
     end


### PR DESCRIPTION
Remove `WavePropBase` as a dependency, and port the required functionality directly to `HMatrices`. This makes it easier to understand the code, and it removes many indirect dependencies related to `WavePropBase`. 

This `PR` also starts using `JuliaFormatter` for auto-formatting the files.