### PR TITLE
Static partition for matrix/vector product

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HMatrices"
 uuid = "8646bddf-ab1c-4fa7-9c51-ba187d647618"
 authors = ["Luiz M. Faria <maltezfaria@gmail.com> and contributors"]
-version = "0.2"
+version = "0.2.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/HMatrices.jl
+++ b/src/HMatrices.jl
@@ -22,7 +22,7 @@ import Base: Matrix, adjoint, parent
 If set to false, the `getindex(H,i,j)` method will throw an error on
 `AbstractHMatrix`.
 """
-const ALLOW_GETINDEX = Ref(false)
+const ALLOW_GETINDEX = Ref(true)
 
 """
     use_threads()::Bool

--- a/src/HMatrices.jl
+++ b/src/HMatrices.jl
@@ -22,7 +22,7 @@ import Base: Matrix, adjoint, parent
 If set to false, the `getindex(H,i,j)` method will throw an error on
 `AbstractHMatrix`.
 """
-const ALLOW_GETINDEX = Ref(true)
+const ALLOW_GETINDEX = Ref(false)
 
 """
     use_threads()::Bool


### PR DESCRIPTION
Switch to a static partition when multiplying an `HMatrix` by a vector. This reduces the number of `Task`s created, and thus the memory allocated. The difficulty is that the static partition may not be very good at load balancing. To alleviate this issue, the static partitioner uses a cost estimate of the tasks, and attempts to split the leaves in a way that is both local, and approximately balanced as per a certain *cost function*.

The implementation of various partitions is in the `partitions.jl` file.