### PR TITLE
Disable `getindex` for `RkMatrix` and `HMatrix` types

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,24 +1,34 @@
 using HMatrices
 using Documenter
 
-DocMeta.setdocmeta!(HMatrices, :DocTestSetup, :(using HMatrices); recursive=true)
+DocMeta.setdocmeta!(HMatrices, :DocTestSetup, :(using HMatrices); recursive = true)
+
+on_CI = get(ENV, "CI", "false") == "true"
 
 makedocs(;
-         modules=[HMatrices],
-         authors="Luiz M. Faria <maltezfaria@gmail.com> and contributors",
-         repo="https://github.com/WaveProp/HMatrices.jl/blob/{commit}{path}#{line}",
-         sitename="HMatrices.jl",
-         format=Documenter.HTML(;
-                                prettyurls=get(ENV, "CI", "false") == "true",
-                                canonical="https://WaveProp.github.io/HMatrices.jl",
-                                assets=String[]),
-         pages=["Getting started" => "index.md",
-                "Kernel matrices" => "kernelmatrix.md",
-                "Distributed HMatrix" => "dhmatrix.md",
-                "Notebooks" => "notebooks.md",
-                "Benchmarks" => ["benchs.md"],
-                "References" => "references.md"])
+    modules = [HMatrices],
+    authors = "Luiz M. Faria <maltezfaria@gmail.com> and contributors",
+    repo = "",
+    sitename = "HMatrices.jl",
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://WaveProp.github.io/HMatrices.jl",
+        assets = String[],
+    ),
+    pages = [
+        "Getting started" => "index.md",
+        "Kernel matrices" => "kernelmatrix.md",
+        "Distributed HMatrix" => "dhmatrix.md",
+        "Notebooks" => "notebooks.md",
+        "Benchmarks" => ["benchs.md"],
+        "References" => "references.md",
+    ],
+    warnonly = on_CI ? false : Documenter.except(:linkcheck_remotes),
+    pagesonly = true,
+)
 
 deploydocs(;
-           repo="github.com/WaveProp/HMatrices.jl",
-           devbranch="main")
+    repo = "github.com/WaveProp/HMatrices.jl",
+    devbranch = "main",
+    push_preview = false,
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -142,18 +142,6 @@ H = assemble_hmatrix(K,Xclt,Yclt;adm,comp,threads=false,distributed=false)
 You can now use `H` *in lieu* of `K` (as an approximation) for certain linear
 algebra operations, as shown next.
 
-!!! tip "Disabling `getindex`"
-    Although the `getindex(H,i::Int,j::Int)` method is defined for an `AbstractHMatrix`, its use
-    is mostly for display purposes in a `REPL` environment, and should be
-    avoided in any linear algebra routine. To avoid the performance pitfalls
-    related to methods falling back to the generic `LinearAlgebra`
-    implementation of various algorithms (which make use `getindex`
-    extensively), you can disable `getindex` on types defined in this package by
-    calling [`HMatrices.disable_getindex`](@ref). The consequence is that
-    calling `getindex(H,i,j)` will throw an error. If a given operation is
-    running unexpectedly slow, try disabling `getindex` to see if any part of
-    the code is falling back to a generic implementation.
-
 ## Matrix vector product and iterative solvers
 
 The simplest operation you can perform with an `HMatrix` is to multiply it by a

--- a/docs/src/kernelmatrix.md
+++ b/docs/src/kernelmatrix.md
@@ -78,7 +78,9 @@ You can now multiply `H` by a density `σ`, where `σ` is a `Vector` of
 y = H*σ
 # test the output agains the exact value for a given `i`
 i = 42
-y[i] - sum(K[i,j]*σ[j] for j in 1:m)
+exact = sum(K[i,j]*σ[j] for j in 1:m)
+@assert norm(y[i] - exact) < 1e-4 # hide
+@show y[i] - exact
 ```
 
 !!! note

--- a/src/HMatrices.jl
+++ b/src/HMatrices.jl
@@ -19,10 +19,10 @@ import Base: Matrix, adjoint, parent
 """
     const ALLOW_GETINDEX
 
-If set to false, the `getindex(H,i,j)` method will throw an error on
-`AbstractHMatrix`.
+If set to false (default), the `getindex(H,i,j)` method will throw an error on
+[`AbstractHMatrix`](@ref) and [`RkMatrix`](@ref).
 """
-const ALLOW_GETINDEX = Ref(true)
+const ALLOW_GETINDEX = Ref(false)
 
 """
     use_threads()::Bool

--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -1,3 +1,8 @@
+"""
+    abstract type AbstractHMatrix{T} <: AbstractMatrix{T}
+
+Abstract type for hierarchical matrices.
+"""
 abstract type AbstractHMatrix{T} <: AbstractMatrix{T} end
 
 function Base.getindex(H::AbstractHMatrix, i::Int, j::Int)

--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -1,28 +1,17 @@
 abstract type AbstractHMatrix{T} <: AbstractMatrix{T} end
 
-function Base.getindex(H::AbstractHMatrix, i, j)
-    # NOTE: you may disable `getindex` to avoid having code that will work, but be
-    # horribly slow because it falls back to some generic implementation in
-    # LinearAlgebra. The downside is that the `show` method, which will usually
-    # call `getindex` for `AbstractMatrix`, has to be overloaded too. One
-    # options is not not inherit from `AbstractMatrix` since we don't have an
-    # efficient `getindex` method in any case. The downside is that some
-    # convenient functionality of `AbstractMatrix` will be lost.
-    msg = """
-    method `getindex(::AbstractHMatrix,args...)` has been disabled to avoid
-    performance pitfalls. Unless you made an explicit call to `getindex`, this
-    error usually means that a linear algebra routine involving an
-    `AbstractHMatrix` has fallen back to a generic implementation.
-    """
+function Base.getindex(H::AbstractHMatrix, i::Int, j::Int)
     if ALLOW_GETINDEX[]
+        iloc = glob2loc(rowtree(H))[i]
+        jloc = glob2loc(coltree(H))[j]
         shift = pivot(H) .- 1
-        _getindex(H, i + shift[1], j + shift[2])
+        _getindex(H, iloc + shift[1], jloc + shift[2])
     else
-        error(msg)
+        error(GET_INDEX_ERROR_MSG)
     end
 end
 
-function _getindex(H, i, j)
+function _getindex(H, i::Int, j::Int)
     (i ∈ rowrange(H)) && (j ∈ colrange(H)) || throw(BoundsError(H, (i, j)))
     acc = zero(eltype(H))
     shift = pivot(H) .- 1
@@ -74,8 +63,6 @@ coltree(H::AbstractHMatrix) = H.coltree
 
 cluster_type(::HMatrix{R,T}) where {R,T} = R
 
-Base.getindex(H::HMatrix, ::Colon, j) = getcol(H, j)
-
 # getcol for regular matrices
 function getcol!(col, M::Matrix, j)
     @assert length(col) == size(M, 1)
@@ -116,8 +103,6 @@ function _getcol!(col, H::HMatrix, j, piv)
     end
     return col
 end
-
-Base.getindex(adjH::Adjoint{<:Any,<:HMatrix}, ::Colon, j) = getcol(adjH, j)
 
 function getcol(adjH::Adjoint{<:Any,<:HMatrix}, j::Int)
     # (j ∈ colrange(adjH)) || throw(BoundsError())
@@ -225,12 +210,12 @@ function _show(io, hmat)
 end
 
 """
-    Matrix(H::HMatrix;global_index=false)
+    Matrix(H::HMatrix;global_index=true)
 
-Convert `H` to a `Matrix`. If `global_index=true`, the entries are given in the
-global indexing system (see [`HMatrix`](@ref) for more information); otherwise
-the *local* indexing system induced by the row and columns trees are used
-(default).
+Convert `H` to a `Matrix`. If `global_index=true` (the default), the entries are
+given in the global indexing system (see [`HMatrix`](@ref) for more
+information); otherwise the *local* indexing system induced by the row and
+columns trees are used.
 """
 Matrix(hmat::HMatrix; global_index=true) = Matrix{eltype(hmat)}(hmat; global_index)
 function Base.Matrix{T}(hmat::HMatrix; global_index) where {T}

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -1,6 +1,8 @@
 const NOPIVOT = VERSION >= v"1.7" ? NoPivot : Val{false}
 
-function Base.getproperty(LU::LU{<:Any,<:HMatrix}, s::Symbol)
+const HLU = LU{<:Any,<:HMatrix}
+
+function Base.getproperty(LU::HLU, s::Symbol)
     H = getfield(LU, :factors) # the underlying hierarchical matrix
     if s == :L
         return UnitLowerTriangular(H)
@@ -9,6 +11,11 @@ function Base.getproperty(LU::LU{<:Any,<:HMatrix}, s::Symbol)
     else
         return getfield(LU, s)
     end
+end
+
+function Base.show(io::IO, ::MIME"text/plain", LU::HLU)
+    H = getfield(LU, :factors) # the underlying hierarchical matrix
+    println(io, "LU factorization of $H")
 end
 
 """

--- a/src/rkmatrix.jl
+++ b/src/rkmatrix.jl
@@ -33,13 +33,11 @@ function Base.setproperty!(R::RkMatrix, s::Symbol, mat::Matrix)
     return R
 end
 
+function Base.show(io::IO, ::MIME"text/plain", R::RkMatrix)
+    print(io, size(R,1), "×", size(R,2), " RkMatrix{", eltype(R), "}",  " of rank ", rank(R))
+end
+
 function Base.getindex(rmat::RkMatrix, i::Int, j::Int)
-    msg = """
-    method `getindex(::AbstractHMatrix,args...)` has been disabled to avoid
-    performance pitfalls. Unless you made an explicit call to `getindex`, this
-    error usually means that a linear algebra routine involving an
-    `AbstractHMatrix` has fallen back to a generic implementation.
-    """
     if ALLOW_GETINDEX[]
         r = rank(rmat)
         acc = zero(eltype(rmat))
@@ -47,7 +45,7 @@ function Base.getindex(rmat::RkMatrix, i::Int, j::Int)
             acc += rmat.A[i, k] * conj(rmat.B[j, k])
         end
     else
-        error(msg)
+        error(GET_INDEX_ERROR_MSG)
     end
     return acc
 end
@@ -240,3 +238,6 @@ function mul!(C::AbstractVector, Rk::RkMatrix{T}, F::AbstractVector, a::Number,
     end
     return C
 end
+
+# scalar multiplication
+Base.:*(a::Number, R::RkMatrix) = (A = a * R.A; B = copy(R.B); RkMatrix(A, B))

--- a/src/splitter.jl
+++ b/src/splitter.jl
@@ -139,7 +139,7 @@ function binary_split!(cluster::ClusterTree{N,T}, predicate::Function) where {N,
     els = root_elements(cluster)
     irange = index_range(cluster)
     n = length(irange)
-    buff = view(cluster.buffer, irange)
+    buff = view(cluster.glob2loc, irange) # use as a temporary buffer
     l2g = loc2glob(cluster)
     npts_left = 0
     npts_right = 0
@@ -169,7 +169,7 @@ function binary_split!(cluster::ClusterTree{N,T}, predicate::Function) where {N,
     left_indices = (irange.start):((irange.start) + npts_left - 1)
     right_indices = (irange.start + npts_left):(irange.stop)
     # create children
-    clt1 = ClusterTree(els, left_rec, left_indices, l2g, cluster.buffer, nothing, cluster)
-    clt2 = ClusterTree(els, right_rec, right_indices, l2g, cluster.buffer, nothing, cluster)
+    clt1 = ClusterTree(els, left_rec, left_indices, l2g, cluster.glob2loc, nothing, cluster)
+    clt2 = ClusterTree(els, right_rec, right_indices, l2g, cluster.glob2loc, nothing, cluster)
     return clt1, clt2
 end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1,6 +1,16 @@
 const HUnitLowerTriangular = UnitLowerTriangular{<:Any,<:HMatrix}
 const HUpperTriangular = UpperTriangular{<:Any,<:HMatrix}
 
+function Base.show(io::IO, ::MIME"text/plain", U::HUpperTriangular)
+    H = parent(U)
+    println(io, "Upper triangular part of $H")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", L::HUnitLowerTriangular)
+    H = parent(L)
+    println(io, "Unit lower triangular part of $H")
+end
+
 function ldiv!(L::HUnitLowerTriangular, B::AbstractMatrix)
     H = parent(L)
     if isleaf(H)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -122,21 +122,24 @@ function hilbert_points(n::Integer)
 end
 
 """
-    disable_getindex()
+    allow_getindex(bool)
 
-Call this function to disable the `getindex` method on `AbstractHMatrix`. This
-is useful to avoid performance pitfalls associated with linear algebra methods
-falling back to a generic implementation which uses the `getindex` method.
-Calling `getindex(H,i,j)` will error after calling this function.
-"""
-disable_getindex() = (ALLOW_GETINDEX[] = false)
+Call this function to enable/disable the `getindex` method on `AbstractHMatrix`
+and `RkMatrix`.
 
+By default, calling `getindex` on these types will error to avoid performance
+pitfalls associated with linear algebra methods falling back to a generic
+implementation which uses the `getindex` method.
 """
-    enable_getindex()
+allow_getindex(bool) = (ALLOW_GETINDEX[] = bool)
 
-The opposite of [`disable_getindex`](@ref).
+const GET_INDEX_ERROR_MSG = """
+method `getindex(::Union{AbstractHMatrix,RkMatrix},args...)` has been disabled
+to avoid performance pitfalls. Unless you made an explicit call to `getindex`,
+this error usually means that a linear algebra routine involving an
+`AbstractHMatrix` has fallen back to a generic implementation. Calling
+`allow_getindex(true)` fixes this error.
 """
-enable_getindex() = (ALLOW_GETINDEX[] = true)
 
 """
     filter_tree(f,tree,isterminal=true)

--- a/test/triangular_test.jl
+++ b/test/triangular_test.jl
@@ -69,7 +69,7 @@ end
     ## 3.2
     exact = rdiv!(copy(R_full), UpperTriangular(H_full))
     approx = rdiv!(copy(R), UpperTriangular(H))
-    @test exact ≈ approx
+    @test exact ≈ Matrix(approx)
 
     ## 3.3
     compressor = PartialACA(; atol=1e-10)


### PR DESCRIPTION
Undoes the (bad?) design choice to implement the `getindex` method for things like `HMatrix` and `RkMatrix`. Since these types inherit from `AbstractMatrix`, having a `getindex` method means many fallback generic algorithms are available for various linear algebra operations. While that may seem like an advantage at first, it leads to many "silent performance problems", where we are unknowingly using some slow generic routine. After running into a couple of such issues, I have decided to disable the `getindex` on these types by default (they do not support *fast* indexing anyways) so that it throws an error if called. 

The changes are somewhat global because I had to overload the `show` method for many types so that it would not call `getindex` when displaying instances of these types. 