### PR TITLE
Support for `gemm` operations

### DIFF
--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -557,6 +557,18 @@ function mul!(
     return y
 end
 
+# FIXME: for matrix multiplication, we slice into columns and call the gemv
+# routine. This is a somewhat inneficient way of doing things, but it is simple
+# enough.
+function mul!(Y::AbstractMatrix, A::HMatrix, X::AbstractMatrix, a::Number=1, b::Number=0;
+              kwargs...)
+    size(Y, 2) == size(X, 2) || Throw(DimensionMismatch("size(Y,2) != size(X,2)"))
+    for k in 1:size(Y, 2)
+        mul!(view(Y, :, k), A, view(X, :, k), a, b; kwargs...)
+    end
+    return Y
+end
+
 """
     _hgemv_recursive!(C,A,B,offset)
 

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -470,8 +470,8 @@ end
 
 # 1.2.1
 function mul!(y::AbstractVector, R::RkMatrix, x::AbstractVector, a::Number, b::Number)
-    # tmp = R.Bt*x
-    tmp = mul!(R.buffer, adjoint(R.B), x)
+    tmp = R.Bt * x
+    # tmp = mul!(R.buffer, adjoint(R.B), x)
     return mul!(y, R.A, tmp, a, b)
 end
 
@@ -484,8 +484,8 @@ function mul!(
     b::Number,
 )
     R = parent(adjR)
-    # tmp = R.At*x
-    tmp = mul!(R.buffer, adjoint(R.A), x)
+    tmp = R.At * x
+    # tmp = mul!(R.buffer, adjoint(R.A), x)
     return mul!(y, R.B, tmp, a, b)
 end
 

--- a/test/multiplication_test.jl
+++ b/test/multiplication_test.jl
@@ -61,3 +61,31 @@ end
         @test exact ≈ approx
     end
 end
+
+@testset "gemm" begin
+    α = rand() - 0.5
+    β = rand() - 0.5
+    T = eltype(H)
+    m, n = size(H)
+    k = 10
+    x = rand(T, n, k)
+    y = rand(T, m, k)
+
+    @testset "serial" begin
+        exact = β * y + α * H_full * x
+        approx = mul!(copy(y), H, x, α, β; threads=false, global_index=false)
+        @test exact ≈ approx
+        exact = β * y + α * Matrix(H; global_index=true) * x
+        approx = mul!(copy(y), H, x, α, β; threads=false, global_index=true)
+        @test exact ≈ approx
+    end
+
+    @testset "threads" begin
+        exact = β * y + α * H_full * x
+        approx = mul!(copy(y), H, x, α, β; threads=true, global_index=false)
+        @test exact ≈ approx
+        exact = β * y + α * Matrix(H; global_index=true) * x
+        approx = mul!(copy(y), H, x, α, β; threads=false, global_index=true)
+        @test exact ≈ approx
+    end
+end

--- a/test/rkmatrix_test.jl
+++ b/test/rkmatrix_test.jl
@@ -21,8 +21,8 @@ using HMatrices: RkMatrix, compression_ratio
         @test rank(R) == r
         @test Matrix(R) ≈ M
         @test compression_ratio(R) ≈ m * n / (r * (m + n))
-        @test R[:, 5] ≈ M[:, 5]
-        @test Ra[:, 5] ≈ Ma[:, 5]
+        @test HMatrices.getcol(R,5) ≈ M[:, 5]
+        @test HMatrices.getcol(Ra,5) ≈ Ma[:, 5]
     end
 
     @testset "Matrix entries" begin


### PR DESCRIPTION
- Implements a *naive* version of the hmatrix-matrix product.
- Remove the buffer from `RkMatrix` so that a single `H*x` can be done in parallel for several vectors `x`. With the buffer the `gemv` operation was not thread safe.