### PR TITLE
More flexible sparse matrix `axpy!`

### DIFF
--- a/src/compressor.jl
+++ b/src/compressor.jl
@@ -189,12 +189,12 @@ function _aca_partial_pivot(v, J)
     idx = -1
     val = -Inf
     for n in 1:length(J)
-        J[n] || continue
         x = v[n]
         σ = svdvals(x)[end]
-        σ < val && continue
-        idx = n
-        val = σ
+        if σ > val && J[n]
+            idx = n
+            val = σ
+        end
     end
     return idx
 end

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -218,12 +218,7 @@ function _mul_dense!(C::Base.Matrix, A, B, a)
     end
 end
 
-function _mul111!(
-    C,
-    A,
-    B,
-    a,
-)
+function _mul111!(C, A, B, a)
     return mul!(C, A, B, a, true)
 end
 


### PR DESCRIPTION
This `PR` allows an arbitrary sparse matrix to be added to an `HMatrix`. This is useful when doing integral equations, where we need to correct a few entries in the matrix due to the singular nature of the kernels. 