### PR TITLE
Buffer for ACA and channels for threads

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -30,5 +30,5 @@ makedocs(;
 deploydocs(;
     repo = "github.com/WaveProp/HMatrices.jl",
     devbranch = "main",
-    push_preview = false,
+    push_preview = true,
 )

--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -260,8 +260,12 @@ end
 @deprecate assemble_hmat assemble_hmatrix
 
 """
-    assemble_hmatrix([T,], K,rowtree,coltree;adm=StrongAdmissibilityStd(),comp=PartialACA(),threads=true,distributed=false,global_index=true)
-    assemble_hmatrix([T,], K::KernelMatrix;threads=true,distributed=false,global_index=true,[rtol],[atol],[rank])
+    assemble_hmatrix([T,], K, rowtree, coltree;
+        adm=StrongAdmissibilityStd(),
+        comp=PartialACA(),
+        threads=true,
+        distributed=false,
+        global_index=true)
 
 Main routine for assembling a hierarchical matrix. The argument `K` represents
 the matrix to be approximated, `rowtree` and `coltree` are tree structure
@@ -276,9 +280,6 @@ of `K[irange,jrange]` in the form of an [`RkMatrix`](@ref).
 
 The type paramter `T` is used to specify the type of the entries of the matrix,
 by default is inferred from `K` using `eltype(K)`.
-
-For best performance, you want to
-- permute the entries of the
 """
 function assemble_hmatrix(
     ::Type{T},
@@ -312,22 +313,6 @@ end
 
 function assemble_hmatrix(K::AbstractMatrix, args...; kwargs...)
     return assemble_hmatrix(eltype(K), K, args...; kwargs...)
-end
-
-function assemble_hmatrix(
-    K::AbstractKernelMatrix;
-    atol = 0,
-    rank = typemax(Int),
-    rtol = atol > 0 || rank < typemax(Int) ? 0 : sqrt(eps(Float64)),
-    kwargs...,
-)
-    comp = PartialACA(; rtol, atol, rank)
-    adm = StrongAdmissibilityStd()
-    X = rowelements(K)
-    Y = colelements(K)
-    Xclt = ClusterTree(X)
-    Yclt = ClusterTree(Y)
-    return assemble_hmatrix(K, Xclt, Yclt; adm, comp, kwargs...)
 end
 
 """

--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -300,12 +300,10 @@ function assemble_hmatrix(
         global_index && (K = PermutedMatrix(K, loc2glob(rowtree), loc2glob(coltree)))
         # now assemble the data in the blocks
         if threads
-            bufs = [
-                (VectorOfVectors(T, 0), VectorOfVectors(T, 0)) for _ in 1:Threads.nthreads()
-            ]
+            bufs = [ACABuffer(T) for _ in 1:Threads.nthreads()]
             _assemble_threads!(hmat, K, comp, bufs)
         else
-            bufs = (VectorOfVectors(T, 0), VectorOfVectors(T, 0))
+            bufs = ACABuffer(T)
             _assemble_cpu!(hmat, K, comp, bufs)
         end
     end

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -27,8 +27,10 @@ blocks during the multiplication routines.
 function LinearAlgebra.lu!(M::HMatrix, compressor; threads = use_threads())
     # perform the lu decomposition of M in place
     T = eltype(M)
-    buffers = [ACABuffer(T) for _ in 1:Threads.nthreads()]
-    _lu!(M, compressor, threads, buffers)
+    nt = Threads.nthreads()
+    chn = Channel{ACABuffer{T}}(nt)
+    foreach(i -> put!(chn, ACABuffer(T)), 1:nt)
+    _lu!(M, compressor, threads, chn)
     # wrap the result in the LU structure
     return LU(M, LinearAlgebra.BlasInt[], LinearAlgebra.BlasInt(0))
 end

--- a/src/lu.jl
+++ b/src/lu.jl
@@ -27,7 +27,7 @@ blocks during the multiplication routines.
 function LinearAlgebra.lu!(M::HMatrix, compressor; threads = use_threads())
     # perform the lu decomposition of M in place
     T = eltype(M)
-    buffers = [(VectorOfVectors(T), VectorOfVectors(T)) for _ in 1:Threads.nthreads()]
+    buffers = [ACABuffer(T) for _ in 1:Threads.nthreads()]
     _lu!(M, compressor, threads, buffers)
     # wrap the result in the LU structure
     return LU(M, LinearAlgebra.BlasInt[], LinearAlgebra.BlasInt(0))

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -9,7 +9,7 @@ addition is performed.
 function hmul!(C::T, A::T, B::T, a, b, compressor, bufs_ = nothing) where {T<:HMatrix}
     bufs = if isnothing(bufs_)
         S = eltype(C)
-        [(VectorOfVectors(S), VectorOfVectors(S)) for _ in 1:Threads.nthreads()]
+        [ACABuffer(S) for _ in 1:Threads.nthreads()]
     else
         bufs_
     end


### PR DESCRIPTION
- [x] Implement an `ACABuffer` 
- [x] Fix possible thread-safe issues due to the use of `threadid`
- [x] Improve docs on how to use `KernelMatrix` when the elements are things other than points. 